### PR TITLE
Fix formatting and remove speculative content

### DIFF
--- a/docs/papers/agentic-tools/index.md
+++ b/docs/papers/agentic-tools/index.md
@@ -16,7 +16,7 @@ All observations are time-bound to January 2026. These tools evolve rapidly, and
 
 This paper is intended to help you reason about architectural tradeoffs, not to recommend a single "best" tool. Organizations vary in constraints such as editor standardization, compliance requirements, existing vendor contracts, developer experience maturity, and cost sensitivity. The goal is to describe the execution models clearly enough that teams can map them to their own constraints.
 
-**Disclosure:** I use Cursor in a work setting because that is the standardized tool available, I pay for Claude Code personally, and I am actively evaluating Goose for both personal and professional use.
+**Disclosure:** I use Cursor at work, I pay for Claude Code personally, and I am actively evaluating Goose for both personal and professional use.
 
 ## Target Audience
 

--- a/docs/papers/sdd-frameworks/adjacent-technologies.md
+++ b/docs/papers/sdd-frameworks/adjacent-technologies.md
@@ -591,86 +591,39 @@ The integration of AI agents, SDD frameworks, and modern tooling enables entirel
 
 #### For Greenfield Projects
 
-**Core SDD:** BMAD or SpecKit
-**Multi-Agent:** MetaGPT
-**BDD Testing:** Cucumber or Momentic
-**Contract Testing:** Pact
-**AI Assistance:** GitHub Copilot + Claude
+| Component | Recommendation |
+|-----------|----------------|
+| Core SDD | BMAD or SpecKit |
+| Multi-Agent | MetaGPT |
+| BDD Testing | Cucumber or Momentic |
+| Contract Testing | Pact |
+| AI Assistance | GitHub Copilot + Claude |
 
 **Why:** Maximum automation, clear specifications from start
 
 #### For Brownfield Projects
 
-**Core SDD:** OpenSpec
-**Multi-Agent:** LangGraph or CrewAI (lighter weight)
-**BDD Testing:** Cucumber (integrates with existing tests)
-**Contract Testing:** Spring Cloud Contract (if Java)
-**AI Assistance:** Claude for specification inference
+| Component | Recommendation |
+|-----------|----------------|
+| Core SDD | OpenSpec |
+| Multi-Agent | LangGraph or CrewAI (lighter weight) |
+| BDD Testing | Cucumber (integrates with existing tests) |
+| Contract Testing | Spring Cloud Contract (if Java) |
+| AI Assistance | Claude for specification inference |
 
 **Why:** Incremental adoption, minimal disruption
 
 #### For Microservices Architectures
 
-**Core SDD:** SpecKit (governance) + OpenSpec (per-service)
-**Multi-Agent:** MetaGPT (per service) + AutoGen (coordination)
-**BDD Testing:** Cucumber
-**Contract Testing:** Pact + PactFlow
-**AI Assistance:** Full stack (Copilot, Claude, specialized agents)
+| Component | Recommendation |
+|-----------|----------------|
+| Core SDD | SpecKit (governance) + OpenSpec (per-service) |
+| Multi-Agent | MetaGPT (per service) + AutoGen (coordination) |
+| BDD Testing | Cucumber |
+| Contract Testing | Pact + PactFlow |
+| AI Assistance | Full stack (Copilot, Claude, specialized agents) |
 
 **Why:** Strong governance with service autonomy
-
-## Future Trends and Predictions
-
-### Short Term (2026)
-
-**Increased AI Integration:**
-- Every SDD framework will have native AI agent support
-- Specification generation becomes primarily AI-driven
-- Human role shifts to review and refinement
-
-**MCP Standardization:**
-- SDD frameworks adopt MCP for agent coordination
-- Cross-framework agent interoperability
-- Standard specification formats emerge
-
-**Tool Consolidation:**
-- Major platforms (GitHub, GitLab) bundle SDD capabilities
-- Integrated AI + SDD + CI/CD pipelines
-- Reduced tool sprawl
-
-### Medium Term (2027-2028)
-
-**Autonomous Development Teams:**
-- Complete features developed by AI agent teams
-- Human oversight focuses on strategy and validation
-- Specifications become primary human contribution
-
-**Self-Evolving Specifications:**
-- AI agents propose specification improvements
-- Automated A/B testing of specification approaches
-- Specifications evolve based on production data
-
-**Industry-Specific SDD Frameworks:**
-- Fintech-specific SDD with regulatory compliance
-- Healthcare SDD with HIPAA specifications
-- Automotive SDD with safety certifications
-
-### Long Term (2029+)
-
-**Specification-Native Development:**
-- Code generated entirely from specifications
-- Multiple implementation strategies auto-generated
-- Implementation becomes optimization problem
-
-**AI-Verified Correctness:**
-- Formal verification of specification completeness
-- Mathematical proofs of implementation correctness
-- Zero-defect development becomes achievable
-
-**Conversational Software Development:**
-- Natural language specification authoring
-- AI agents handle all technical translation
-- Software development accessible to non-programmers
 
 ## Conclusion
 


### PR DESCRIPTION
- Simplify Cursor disclosure in agentic-tools paper
- Convert Technology Stack Recommendations to tables for proper rendering
- Remove Future Trends and Predictions section (too speculative)