### PR TITLE
Find and fix a bug

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -8,8 +8,6 @@ export default withMermaid(
     base: '/research/',
 
     themeConfig: {
-      logo: '/logo.svg',
-
       nav: [
         { text: 'Home', link: '/' },
         { text: 'Papers', link: '/papers/' }


### PR DESCRIPTION
The VitePress config referenced /logo.svg but the file didn't exist, causing a broken image icon in the navbar. Removed the logo config entry until a proper logo file is added.