### PR TITLE
Add SEO assessment report documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,26 +23,39 @@ This is a technical research repository hosting comprehensive research papers on
 ### Published Papers
 1. **Spec-Driven Development Frameworks** (January 2026)
    - Location: `docs/papers/sdd-frameworks/`
-   - Content: ~29,000 words
    - Sections: Getting Started, Framework Comparison, Foundational Theory, Adjacent Technologies
    - Frameworks covered: BMAD, SpecKit, OpenSpec
    - Related technologies: MetaGPT, Momentic, Pact, Cucumber, BDD frameworks
+
+2. **Agentic Development Tools and Execution Architectures** (January 2026)
+   - Location: `docs/papers/agentic-tools/`
+   - Sections: Terminology & Taxonomy, Tool Analysis, Comparative Analysis, References
+   - Tools covered: Claude Code, Goose, Cursor, GitHub Copilot
+   - Focus: Execution models, autonomy boundaries, governance implications
 
 ### Repository Structure
 ```
 research/
 ├── .github/workflows/deploy.yml    # GitHub Pages deployment
 ├── docs/
-│   ├── .vitepress/config.js        # VitePress configuration
+│   ├── .vitepress/config.js        # VitePress configuration (sitemap, meta tags, SEO)
+│   ├── public/
+│   │   └── robots.txt              # Search engine crawler instructions
 │   ├── index.md                    # Landing page
 │   ├── papers/
 │   │   ├── index.md                # Papers listing
-│   │   └── sdd-frameworks/         # First research paper
+│   │   ├── sdd-frameworks/         # SDD Frameworks paper
+│   │   │   ├── index.md
+│   │   │   ├── getting-started.md
+│   │   │   ├── frameworks-comparison.md
+│   │   │   ├── foundational-theory.md
+│   │   │   └── adjacent-technologies.md
+│   │   └── agentic-tools/          # Agentic Tools paper
 │   │       ├── index.md
-│   │       ├── getting-started.md
-│   │       ├── frameworks-comparison.md
-│   │       ├── foundational-theory.md
-│   │       └── adjacent-technologies.md
+│   │       ├── terminology-taxonomy.md
+│   │       ├── tool-analysis.md
+│   │       ├── comparative-analysis.md
+│   │       └── references.md
 ├── package.json
 └── README.md
 ```
@@ -195,6 +208,66 @@ flowchart TD
 
 Use `<br/>` for line breaks within node labels. Prefer `flowchart TD` (top-down) for hierarchical diagrams.
 
+## SEO Requirements
+
+All pages must follow SEO best practices to ensure proper indexing and discoverability.
+
+### Frontmatter Requirements (Mandatory)
+
+Every markdown file must include YAML frontmatter with:
+
+```yaml
+---
+title: Page Title (50-60 characters ideal)
+description: Page description for meta tags (150-160 characters ideal)
+---
+```
+
+Example for paper pages:
+```yaml
+---
+title: Spec-Driven Development Framework Patterns
+description: Comprehensive analysis of BMAD, SpecKit, and OpenSpec frameworks for specification-driven development. Includes framework comparison and adoption guidance.
+---
+```
+
+### URL Structure
+
+- Use kebab-case for file names: `getting-started.md`, not `GettingStarted.md`
+- Clean URLs are enabled (no `.html` extensions)
+- Canonical URLs point to `https://daviddaniel.tech/research/`
+
+### Meta Tags (Auto-Generated)
+
+The VitePress config (`docs/.vitepress/config.js`) automatically generates:
+- Canonical URLs per page
+- Open Graph tags (`og:title`, `og:description`, `og:url`)
+- Twitter card tags
+- JSON-LD structured data for paper pages (TechArticle schema)
+
+### SEO Checklist for New Pages
+
+When creating new pages:
+1. Add `title` frontmatter (required)
+2. Add `description` frontmatter (required, 150-160 chars)
+3. Use descriptive H1 heading (should match or relate to title)
+4. Include internal links to related content
+5. Verify page appears in sitemap after build
+
+### Sitemap and Robots
+
+- Sitemap: Auto-generated at `/research/sitemap.xml`
+- Robots.txt: Located at `docs/public/robots.txt`
+- Both are configured and should not need manual updates
+
+### SEO Files Reference
+
+| File | Purpose |
+|------|---------|
+| `docs/.vitepress/config.js` | Sitemap config, meta tags, transformPageData hook |
+| `docs/public/robots.txt` | Search engine crawler instructions |
+| Page frontmatter | Per-page title and description |
+
 ## Future Paper Ideas
 
 Potential topics for expansion:
@@ -287,6 +360,6 @@ When using Claude Code to work on this repository:
 
 ---
 
-**Last Updated:** January 7, 2026  
-**Repository Status:** Ready for initial deployment  
-**Current Papers:** 1 (SDD Frameworks)
+**Last Updated:** January 2026
+**Repository Status:** Production
+**Current Papers:** 2 (SDD Frameworks, Agentic Tools)

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -1,11 +1,117 @@
 import { defineConfig } from 'vitepress'
 import { withMermaid } from 'vitepress-plugin-mermaid'
 
+const siteHostname = 'https://daviddaniel.tech'
+const siteBase = '/research'
+const siteUrl = `${siteHostname}${siteBase}`
+const siteName = 'Research Papers'
+const siteDescription = 'In-depth technical analysis on software development frameworks, AI-powered development, and engineering practices'
+
 export default withMermaid(
   defineConfig({
-    title: 'Research Papers',
-    description: 'In-depth technical analysis on software development frameworks and engineering practices',
+    title: siteName,
+    description: siteDescription,
     base: '/research/',
+
+    // Sitemap configuration
+    sitemap: {
+      hostname: siteHostname,
+      transformItems: (items) => {
+        return items.map(item => {
+          // Prepend base path if not already present
+          const url = item.url.startsWith(siteBase) ? item.url : `${siteBase}${item.url.startsWith('/') ? '' : '/'}${item.url}`
+          return {
+            ...item,
+            url,
+            changefreq: 'monthly',
+            priority: item.url === '' || item.url === '/' ? 1.0 : item.url.includes('papers/') ? 0.8 : 0.6
+          }
+        })
+      }
+    },
+
+    // Enable last updated timestamps for sitemap
+    lastUpdated: true,
+
+    // Clean URLs without .html extension
+    cleanUrls: true,
+
+    // Global head configuration
+    head: [
+      // Basic meta tags
+      ['meta', { name: 'author', content: 'David Daniel' }],
+      ['meta', { name: 'keywords', content: 'spec-driven development, software architecture, development frameworks, BDD, contract testing, agentic tools, AI development, Claude Code, Cursor' }],
+      ['meta', { name: 'robots', content: 'index, follow' }],
+
+      // Canonical base (pages will override with specific URLs)
+      ['link', { rel: 'canonical', href: `${siteUrl}/` }],
+
+      // Open Graph base tags
+      ['meta', { property: 'og:site_name', content: siteName }],
+      ['meta', { property: 'og:type', content: 'website' }],
+      ['meta', { property: 'og:locale', content: 'en_US' }],
+
+      // Twitter card base tags
+      ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
+      ['meta', { name: 'twitter:site', content: '@davidedaniel' }],
+
+      // Theme color
+      ['meta', { name: 'theme-color', content: '#3eaf7c' }]
+    ],
+
+    // Dynamic head tags based on page content
+    transformPageData(pageData) {
+      const canonicalUrl = `${siteUrl}/${pageData.relativePath}`
+        .replace(/index\.md$/, '')
+        .replace(/\.md$/, '')
+
+      // Build page-specific head tags
+      const head = pageData.frontmatter.head || []
+
+      // Add canonical URL
+      head.push(['link', { rel: 'canonical', href: canonicalUrl }])
+
+      // Add Open Graph tags
+      const title = pageData.frontmatter.title || pageData.title || siteName
+      const description = pageData.frontmatter.description || siteDescription
+
+      head.push(['meta', { property: 'og:title', content: title }])
+      head.push(['meta', { property: 'og:description', content: description }])
+      head.push(['meta', { property: 'og:url', content: canonicalUrl }])
+
+      // Twitter card tags
+      head.push(['meta', { name: 'twitter:title', content: title }])
+      head.push(['meta', { name: 'twitter:description', content: description }])
+
+      // Add structured data for paper pages
+      if (pageData.relativePath.includes('papers/') && !pageData.relativePath.endsWith('papers/index.md')) {
+        const structuredData = {
+          '@context': 'https://schema.org',
+          '@type': 'TechArticle',
+          headline: title,
+          description: description,
+          author: {
+            '@type': 'Person',
+            name: 'David Daniel'
+          },
+          publisher: {
+            '@type': 'Person',
+            name: 'David Daniel'
+          },
+          url: canonicalUrl,
+          datePublished: '2026-01-01',
+          dateModified: new Date().toISOString().split('T')[0]
+        }
+
+        head.push([
+          'script',
+          { type: 'application/ld+json' },
+          JSON.stringify(structuredData)
+        ])
+      }
+
+      pageData.frontmatter.head = head
+    },
 
     themeConfig: {
       nav: [
@@ -57,11 +163,6 @@ export default withMermaid(
         }
       }
     },
-
-    head: [
-      ['meta', { name: 'author', content: 'David Daniel' }],
-      ['meta', { name: 'keywords', content: 'spec-driven development, software architecture, development frameworks, BDD, contract testing' }]
-    ],
 
     markdown: {
       lineNumbers: true

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,7 @@
 ---
 layout: home
+title: Research Papers - Technical Analysis on Software Development
+description: In-depth technical analysis on software development frameworks, AI-powered development tools, and engineering practices for architects and engineering professionals.
 
 hero:
   name: Research Papers

--- a/docs/papers/agentic-tools/comparative-analysis.md
+++ b/docs/papers/agentic-tools/comparative-analysis.md
@@ -1,3 +1,8 @@
+---
+title: Agentic Tools Comparative Analysis
+description: Side-by-side architectural comparison of Claude Code, Goose, Cursor, and GitHub Copilot. Includes failure modes, operational risks, and governance implications.
+---
+
 # Comparative Analysis
 
 ## Introduction

--- a/docs/papers/agentic-tools/index.md
+++ b/docs/papers/agentic-tools/index.md
@@ -1,3 +1,8 @@
+---
+title: Agentic Development Tools and Execution Architectures
+description: Architectural comparison of Claude Code, Goose, Cursor, and GitHub Copilot. Analysis of execution models, autonomy boundaries, and context management for enterprise adoption.
+---
+
 # Agentic Development Tools and Execution Architectures
 
 ## Overview

--- a/docs/papers/agentic-tools/references.md
+++ b/docs/papers/agentic-tools/references.md
@@ -1,3 +1,8 @@
+---
+title: Agentic Tools References and Resources
+description: Conclusion and official documentation links for Claude Code, Goose, Cursor, and GitHub Copilot. Resources for further exploration of agentic development tools.
+---
+
 # References and Resources
 
 ## Conclusion

--- a/docs/papers/agentic-tools/terminology-taxonomy.md
+++ b/docs/papers/agentic-tools/terminology-taxonomy.md
@@ -1,3 +1,8 @@
+---
+title: Agentic Tools Terminology and Taxonomy
+description: Key definitions and architectural taxonomy for categorizing agentic development tools. Distinguishes assistive AI, IDE-native agents, platform-embedded agents, and multi-context systems.
+---
+
 # Terminology and Taxonomy
 
 ## Introduction

--- a/docs/papers/agentic-tools/tool-analysis.md
+++ b/docs/papers/agentic-tools/tool-analysis.md
@@ -1,3 +1,8 @@
+---
+title: Agentic Development Tool Analysis
+description: Detailed architectural analysis of Claude Code, Goose, Cursor, and GitHub Copilot. Examines execution models, context management, and integration patterns.
+---
+
 # Tool Analysis
 
 ## Introduction

--- a/docs/papers/index.md
+++ b/docs/papers/index.md
@@ -1,3 +1,8 @@
+---
+title: Research Papers
+description: Browse technical research papers on spec-driven development, agentic tools, software architecture, and modern engineering practices.
+---
+
 # Research Papers
 
 In-depth technical analysis to help engineers evaluate frameworks, tools, and practices.

--- a/docs/papers/sdd-frameworks/adjacent-technologies.md
+++ b/docs/papers/sdd-frameworks/adjacent-technologies.md
@@ -1,3 +1,8 @@
+---
+title: Adjacent Technologies and Ecosystem Integration
+description: Analysis of BDD frameworks (Cucumber, SpecFlow, Behave) and contract testing ecosystems (Pact, PactFlow) that complement specification-driven development.
+---
+
 # Adjacent Technologies & Ecosystem Integration
 
 ## Introduction

--- a/docs/papers/sdd-frameworks/foundational-theory.md
+++ b/docs/papers/sdd-frameworks/foundational-theory.md
@@ -1,3 +1,8 @@
+---
+title: Foundational Theory - Understanding Spec-Driven Development
+description: Deep dive into TDD, BDD, Test Pyramid, and Consumer-Driven Contract testing. Theoretical foundations underlying modern specification-driven development frameworks.
+---
+
 # Foundational Theory: Understanding Spec-Driven Development
 
 ## Introduction

--- a/docs/papers/sdd-frameworks/frameworks-comparison.md
+++ b/docs/papers/sdd-frameworks/frameworks-comparison.md
@@ -1,3 +1,8 @@
+---
+title: Enterprise-Grade SDD Framework Comparison
+description: Detailed comparison of BMAD, SpecKit, and OpenSpec including architectural approaches, workflow stages, enterprise adoption patterns, and decision matrices.
+---
+
 # Enterprise-Grade Framework Comparison
 
 ## Executive Summary

--- a/docs/papers/sdd-frameworks/getting-started.md
+++ b/docs/papers/sdd-frameworks/getting-started.md
@@ -1,3 +1,8 @@
+---
+title: Getting Started with Spec-Driven Development
+description: Practical guide for implementing BMAD, SpecKit, and OpenSpec frameworks. Includes quick-start instructions, core concepts, and framework selection guidance.
+---
+
 # Getting Started with Spec-Driven Development
 
 ## Introduction

--- a/docs/papers/sdd-frameworks/index.md
+++ b/docs/papers/sdd-frameworks/index.md
@@ -1,3 +1,8 @@
+---
+title: Spec-Driven Development Framework Patterns
+description: Comprehensive analysis of BMAD, SpecKit, and OpenSpec frameworks for specification-driven development. Includes framework comparison, foundational theory, and enterprise adoption guidance.
+---
+
 # Spec-Driven Development Framework Patterns
 
 ## Overview

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,0 +1,8 @@
+# robots.txt for daviddaniel.tech/research
+# Allow all search engines to crawl all content
+
+User-agent: *
+Allow: /
+
+# Sitemap location
+Sitemap: https://daviddaniel.tech/research/sitemap.xml


### PR DESCRIPTION
- Add robots.txt in docs/public/ for crawler instructions
- Configure sitemap generation with proper base path handling
- Add global head configuration with Open Graph and Twitter card tags
- Implement dynamic meta tags via transformPageData hook
- Add JSON-LD structured data (TechArticle schema) for paper pages
- Add SEO frontmatter (title, description) to all markdown files
- Update CLAUDE.md with SEO requirements section for future maintenance