### PR TITLE
Add articles and autonomous agents paper

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -5,7 +5,7 @@ import { RssPlugin } from 'vitepress-plugin-rss'
 const siteHostname = 'https://daviddaniel.tech'
 const siteBase = '/research'
 const siteUrl = `${siteHostname}${siteBase}`
-const siteName = 'Research Papers'
+const siteName = 'Research'
 const siteDescription = 'In-depth technical analysis on software development frameworks, AI-powered development, and engineering practices'
 
 const rssOptions = {
@@ -39,7 +39,7 @@ export default withMermaid(
             ...item,
             url,
             changefreq: 'monthly',
-            priority: item.url === '' || item.url === '/' ? 1.0 : item.url.includes('papers/') ? 0.8 : 0.6
+            priority: item.url === '' || item.url === '/' ? 1.0 : (item.url.includes('papers/') || item.url.includes('articles/')) ? 0.8 : 0.6
           }
         })
       }
@@ -51,10 +51,8 @@ export default withMermaid(
     // Clean URLs without .html extension
     cleanUrls: true,
 
-    // Ignore dead links to companion articles not yet published
-    ignoreDeadLinks: [
-      /\/articles\//
-    ],
+    // Ignore dead links to external anchor targets that may not resolve at build time
+    ignoreDeadLinks: [],
 
     // Global head configuration
     head: [
@@ -106,8 +104,10 @@ export default withMermaid(
       head.push(['meta', { name: 'twitter:title', content: title }])
       head.push(['meta', { name: 'twitter:description', content: description }])
 
-      // Add structured data for paper pages
-      if (pageData.relativePath.includes('papers/') && !pageData.relativePath.endsWith('papers/index.md')) {
+      // Add structured data for paper and article pages
+      const isPaperPage = pageData.relativePath.includes('papers/') && !pageData.relativePath.endsWith('papers/index.md')
+      const isArticlePage = pageData.relativePath.includes('articles/') && !pageData.relativePath.endsWith('articles/index.md')
+      if (isPaperPage || isArticlePage) {
         const structuredData = {
           '@context': 'https://schema.org',
           '@type': 'TechArticle',
@@ -139,10 +139,29 @@ export default withMermaid(
     themeConfig: {
       nav: [
         { text: 'Home', link: '/' },
+        { text: 'Articles', link: '/articles/' },
         { text: 'Papers', link: '/papers/' }
       ],
 
       sidebar: {
+        '/articles/specification-layer/': [
+          {
+            text: 'Scaling Agentic Development',
+            items: [
+              { text: 'The Specification Layer', link: '/articles/specification-layer/' },
+              { text: 'The Autonomous Agents Loop', link: '/articles/autonomous-agents-loop/' }
+            ]
+          }
+        ],
+        '/articles/autonomous-agents-loop/': [
+          {
+            text: 'Scaling Agentic Development',
+            items: [
+              { text: 'The Specification Layer', link: '/articles/specification-layer/' },
+              { text: 'The Autonomous Agents Loop', link: '/articles/autonomous-agents-loop/' }
+            ]
+          }
+        ],
         '/papers/sdd-frameworks/': [
           {
             text: 'Spec-Driven Development Framework Patterns',

--- a/docs/articles/autonomous-agents-loop/index.md
+++ b/docs/articles/autonomous-agents-loop/index.md
@@ -1,0 +1,154 @@
+---
+title: "The Autonomous Agents Loop: Why AI Agents Produce Better Output When You Stop Interrupting Them"
+description: Why autonomous AI execution loops outperform interactive assistance, and how enterprises can build the execution environment, context management, and multi-agent infrastructure to capture those gains.
+---
+
+# The Autonomous Agents Loop: Why AI Agents Produce Better Output When You Stop Interrupting Them
+
+*Part 2 of 2: Scaling Agentic Development for Enterprise Teams*
+
+**Published:** February 2026 | **Author:** David Daniel
+
+---
+
+There's a counterintuitive finding buried in the early research on AI-assisted development: the more you interact with an AI coding agent, the worse the results tend to be.
+
+The METR study found experienced developers were 19 percent slower with AI tools despite feeling 20 percent faster (Becker et al., arXiv:2507.09089, July 2025). Faros AI documented 21 percent more tasks completed but 91 percent longer code review times (Faros AI, "The AI Productivity Paradox Research Report," July 2025). The 2025 DORA report found that AI adoption correlates negatively with delivery stability and tends to amplify existing team dynamics rather than compensate for dysfunction (Google Cloud, "Announcing the 2025 DORA Report," September 2025). Stack Overflow recorded its first decline in developer favorability toward AI tools (Stack Overflow 2025 Developer Survey).
+
+These aren't signs that AI coding tools don't work. They're signs that the dominant interaction pattern, human prompts, AI responds, human corrects, AI responds again, doesn't scale. It's the copilot model: tight request-response loops where the human is the orchestrator and the AI is a fast but context-limited assistant.
+
+The teams reporting transformative results have abandoned this model entirely. They've shifted to one where the human writes the specification, the agent runs autonomously through recursive execution loops, and the human reviews the final output. The agent doesn't just write code. It plans, implements, tests, discovers failures, fixes them, and iterates until the specification is met. The human's role shifts from steering every action to defining the destination and reviewing the journey.
+
+This is the autonomous loop, and the evidence from early 2026 shows it produces fundamentally different output than interactive assistance: better code on benchmarks, fewer iteration cycles, and more consistent adherence to machine-verifiable criteria. But it only works when three conditions are met: clear specifications (covered in [Part 1](/articles/specification-layer/)), sufficient execution duration, and managed context across multiple agents.
+
+For a detailed analysis of the evidence supporting these claims, including methodology caveats and the limits of current data, see the companion research paper [Autonomous AI Agents: Execution Loops vs Interactive Assistance](/papers/autonomous-agents/).
+
+## Why Duration Matters
+
+The most visible example of autonomous execution improving output is the Ralph technique, named after Ralph Wiggum from The Simpsons, whose oblivious persistence became the developer community's metaphor for the technique's brute-force approach. The technique is simple: a bash loop runs an AI coding agent (Claude Code, Codex, or others) against a product requirements document. After each iteration, the loop checks whether all tasks in the PRD pass. If not, it runs again. The agent starts each iteration with fresh context while state persists via git history and the filesystem.
+
+Ralph emerged from the open-source community in mid-2025, was formalized into an official Anthropic plugin by Boris Cherny (Head of Claude Code), and by January 2026, VentureBeat called it "the biggest name in AI right now" (VentureBeat, January 7, 2026). The ecosystem exploded across GitHub: `ghuntley/how-to-ralph-wiggum` (the original methodology), `snarktank/ralph` (PRD-driven loop), `frankbria/ralph-claude-code` (with circuit breaker patterns), `mikeyobrien/ralph-orchestrator` (Rust orchestrator with seven backends), and PentoAI's `ml-ralph` (adapted for ML experimentation).
+
+The headline results are dramatic. A developer completed a $50,000 contract for $297 in API costs (self-reported, unaudited; VentureBeat, January 7, 2026). Ralph autonomously built a Gen Z slang-based programming language with an LLVM compiler over a three-month continuous run (Huntley, ghuntley.com/cursed/, September 2025). But the deeper lesson isn't about individual anecdotes. It's about why the loop structure produces better output than interactive coding.
+
+In a single-shot interaction, the agent generates code based on its training data and whatever context fits in the prompt. It can't see its own errors because it can't execute its own code. In an interactive session, the human catches errors and asks for corrections, but each correction happens within a degrading context window where earlier context gets compressed or lost.
+
+In an autonomous loop, the agent writes code, executes it, observes the actual failures (import errors, test failures, type mismatches, runtime exceptions), diagnoses the root cause, fixes it, and runs again. Each iteration operates on *real feedback from real execution*, not the agent's prediction of what might be wrong. This is the same reason human developers run their code constantly: execution-grounded feedback is categorically more useful than reasoning about code in the abstract.
+
+The SWE-bench data quantifies this precisely. As OpenAI reported, GPT-4's performance on SWE-bench Lite varies between 2.7 percent using an early RAG-based scaffold and 28.3 percent using CodeR — roughly an order of magnitude improvement from scaffolding alone (OpenAI, "Introducing SWE-bench Verified," August 2024). By late 2025, frontier agentic systems reached 75 to 80 percent on SWE-bench Verified (Vals AI SWE-bench leaderboard, accessed February 12, 2026). However, contamination-resistant SWE-bench Pro scores remain near 23 percent (Scale AI SWE-bench Pro leaderboard, accessed February 12, 2026), a significant gap that suggests headline numbers overstate general real-world capability. For the full breakdown of benchmark evidence and its limitations, see [Section 1 of the evidence paper](/papers/autonomous-agents/benchmarks#1-agentic-scaffolding-and-swe-bench).
+
+## The Plan-Execute-Verify-Iterate Pattern
+
+Every effective autonomous workflow follows the same fundamental pattern, whether it's Ralph's bash loop, Cursor's background agents, Claude Code's agent teams, or Devin's multi-hour sessions:
+
+**Plan**: The agent reads the specification and decomposes it into steps. In sophisticated implementations, this includes dependency analysis: which steps must happen first, which can run in parallel, where the risks are.
+
+**Execute**: The agent implements one or more steps, writing code, running commands, modifying files.
+
+**Verify**: The agent runs the code (tests, linting, type checking, building) and observes the actual output. This is the critical step that distinguishes autonomous loops from interactive assistance. The agent sees real errors, not hypothetical ones.
+
+**Iterate**: If verification fails, the agent diagnoses the failure and returns to Execute with updated understanding. If verification passes, it moves to the next step in the plan.
+
+The enterprise insight is that this pattern maps directly to existing software engineering practices. Plan-Execute-Verify-Iterate is a formalization of test-driven development, continuous integration, and iterative delivery. The difference is that the agent performs all four steps autonomously, at machine speed, without context-switching overhead.
+
+Cursor's background agents embody this pattern cleanly. Developers fire off a task ("refactor this module to use the new API"), and the agent runs in a cloud-hosted sandbox: planning the migration, executing file-by-file changes, running the test suite, fixing failures, and presenting a completed pull request. The developer's role is to review the PR, not to guide each step.
+
+Claude Code's agent teams (introduced with Opus 4.6 in February 2026) add parallelism to this pattern. A primary agent decomposes a task and delegates sub-tasks to specialized agents, one researching an API, another writing the implementation, a third writing tests, a fourth reviewing for security. Each sub-agent runs its own Plan-Execute-Verify-Iterate loop in an isolated context window. The orchestrator merges results and handles conflicts. Anthropic demonstrated this by having 16 parallel Claude instances build a C compiler from scratch (Carlini, Anthropic Engineering, February 5, 2026). Community reviewers confirmed the compiler passes 99 percent of the GCC torture suite and compiles major open source systems, though community commentary characterized the resulting code as unmaintainable relative to hand-written compilers (ROllerozxa, voxelmanip.se, February 6, 2026). For discussion of what this experiment reveals about the gap between "passes tests" and "production ready," see [Section 2 of the evidence paper](/papers/autonomous-agents/benchmarks#2-large-scale-multi-agent-execution).
+
+Goose (Block's open-source agent framework) and OpenClaw represent the pattern extending beyond development. Goose uses MCP integration for extensible tool chains, enabling agents to connect to databases, APIs, and external services as part of their execution loops. For a comparative analysis of how these tools implement the autonomous loop differently, see [Agentic Development Tools and Execution Architectures](/papers/agentic-tools/).
+
+## Context Management: The Enterprise Scaling Problem
+
+Here's where enterprise adoption gets hard. Autonomous loops work brilliantly for a single agent on a well-defined task. But enterprise development involves multiple agents, long-running sessions, large codebases, and tasks that span days or weeks. The limiting factor is context management.
+
+Every AI model has a finite context window. Claude Opus 4.6 pushed this to 1 million tokens, a major advance, but even that fills up when an agent is navigating a large monorepo, reading documentation, writing code, and maintaining conversation history. When the context window fills, the agent either loses earlier context (degrading output quality) or must compact/summarize (losing detail).
+
+The autonomous loop compounds this problem because each iteration adds to the context window: code written, errors observed, fixes attempted, tests run. A 20-iteration loop can consume tens of thousands of tokens of working state. Without context management, the agent gets *worse* as it runs longer, exactly the opposite of the desired outcome.
+
+The solutions emerging from the current tooling landscape:
+
+**Fresh-context-per-iteration (Ralph pattern)**: Each loop iteration spawns a new agent session with a clean context window. State persists via the filesystem and git history, not the context window. The agent reads the PRD and the current state of the code at the start of each iteration, with no accumulated conversation baggage. This is elegant but loses the agent's reasoning about why it made specific decisions.
+
+**Context compaction (Claude Code)**: Claude Code automatically compacts the context window at approximately 75 percent capacity, summarizing earlier conversation to free space for new work. The Compaction API (Opus 4.6) formalizes this for custom implementations. The trade-off is that compaction is slow and can lose important detail.
+
+**Sub-agent delegation (multi-agent pattern)**: Complex tasks are decomposed and delegated to sub-agents, each with its own context window. The orchestrator maintains the big picture while sub-agents go deep on narrower problems. This is how human teams naturally work: the tech lead holds the architecture while specialists handle implementation.
+
+**Checkpoint and resume (session persistence)**: AGENTS.md and CLAUDE.md files provide persistent context that survives session boundaries. The agent reads these files at the start of every session, getting the equivalent of "where we left off" without consuming context window with conversation history. The `.claude/` directory structure, with agents, skills, commands, and settings, serves as an external memory system.
+
+**Hierarchical specifications**: Nested AGENTS.md/CLAUDE.md files at different directory levels ensure that agents always have the right context for the code they're touching, without loading the entire project's documentation into a single context window. This pattern is examined in detail in the [specification layer article](/articles/specification-layer/).
+
+For enterprises, the context management strategy is the difference between "AI works great for small tasks" and "AI transforms how we build software." The teams reporting the highest productivity gains from agentic development have invested as heavily in context management infrastructure as they have in agent configuration.
+
+## The Multi-Agent Architecture
+
+The highest-performing agentic workflows in early 2026 use multi-agent architectures where specialized agents collaborate on complex tasks. This isn't speculative. It's what the tooling now supports natively.
+
+**Claude Code's Agent Teams** (research preview, February 2026): A lead agent coordinates work across multiple Claude instances running in parallel. Each sub-agent has its own context window, tool access, and behavioral prompt. Sub-agents can be general-purpose or specialized (using `.claude/agents/*.md` definitions). Up to 10 sub-agents can run in parallel.
+
+**Goose (Block)**: Open-source agent framework with MCP server connections for diverse tool access. Goose's architecture enables agents to use any MCP-compatible tool, including databases, APIs, file systems, and browsers, as part of their execution loops. Donated to the AAIF alongside MCP and AGENTS.md, signaling enterprise-readiness.
+
+**Cursor Background Agents**: Cloud-hosted agents that run asynchronously in sandboxed environments. Multiple agents can run simultaneously on different branches. The developer reviews completed PRs rather than guiding execution.
+
+**The Emerging Pattern**: The pattern across all of these is convergent: a primary agent that understands the specification decomposes tasks, delegates to specialized agents with focused context, collects and verifies results, and iterates. Each sub-agent runs its own autonomous loop. The specification layer provides alignment. Context isolation prevents cross-contamination.
+
+This is where the enterprise advantage becomes clear. Individual developers can run one or two agents effectively. Enterprise teams with well-documented conventions, mature testing infrastructure, and clear architectural guidelines can orchestrate entire agent teams, because they already have the specification layer that makes multi-agent coordination reliable.
+
+## Why Autonomous Execution Produces Better Output
+
+The evidence for autonomous execution advantages converges from multiple directions, though with important caveats about the gap between benchmark performance and production readiness. For the complete evidence synthesis, see [Autonomous AI Agents: Execution Loops vs Interactive Assistance](/papers/autonomous-agents/).
+
+**Consistency across files**: An autonomous agent making changes across 30 files maintains a consistent mental model throughout. An interactive session where the human interrupts after each file introduces context-switching that breaks consistency.
+
+**Full iteration cycles**: Autonomous agents complete entire plan-execute-verify-iterate cycles without the "impatience tax," the human tendency to interrupt after seeing the first error rather than letting the agent complete its investigation. Many bugs require multiple steps to diagnose correctly. Cutting the loop short produces surface-level fixes that mask deeper issues.
+
+**Execution-grounded feedback**: Autonomous agents with sandbox access run their own code and observe real failures. This eliminates an entire class of errors, import issues, version mismatches, runtime type errors, that plague generated-but-not-executed code. The agent doesn't guess what might fail; it sees what actually fails.
+
+**Compounding corrections**: Each iteration in an autonomous loop builds on the previous one. The agent that fixed a type error in iteration 3 carries that understanding into iteration 4, where it avoids introducing the same error in a different module. This compounding learning only works when the agent runs long enough to accumulate it.
+
+**A critical caveat on review burden**: The METR study's follow-up evaluation found that while 38 percent of autonomous agent PRs passed automated tests, none were mergeable without human modification, with an average estimated fix time of 42 minutes (METR, "Research Update: Algorithmic vs. Holistic Evaluation," August 2025). Faros AI data shows a 91 percent increase in review time under high AI adoption (Faros AI, July 2025). Autonomous loops don't eliminate the review burden. They shift it from micro-reviews of incremental changes to holistic reviews of complete output. Whether this is a net time savings depends heavily on the quality of specifications and the maturity of the team's automated verification infrastructure.
+
+This explains the resolution of the productivity paradox, at least partially. The METR finding (19 percent slower) applies to the copilot model, where humans stay in the loop at every step. Autonomous execution inverts the time allocation: the agent spends 45 to 90 minutes working while the human does other things, then the human spends time reviewing a complete result. The net productivity gain depends on specification quality, verification infrastructure, and the complexity of the task. The [evidence paper](/papers/autonomous-agents/productivity-evidence#3-randomized-controlled-evidence-on-developer-productivity) examines the specific conditions under which gains materialize and where they don't.
+
+## The Enterprise Playbook
+
+Enterprises that want to capture the productivity gains demonstrated in benchmark and observational data need to invest in three capabilities simultaneously:
+
+**1. Specification infrastructure** (from [Part 1](/articles/specification-layer/))
+
+Build the AGENTS.md / CLAUDE.md / SDD layer that anchors autonomous execution. This is the highest-leverage investment because it improves every agent interaction across every team. Start with repository-level context, expand to package-level specialization, then codify team expertise as reusable agent modules. For framework selection guidance, see [Spec-Driven Development Framework Patterns](/papers/sdd-frameworks/).
+
+**2. Execution environment infrastructure**
+
+Autonomous loops need fast, reliable, sandboxed environments. Agents must be able to run tests, lint code, build the project, and observe real output without human intervention. Slow CI pipelines, flaky tests, and environments that take minutes to spin up directly reduce the value of autonomous execution: each iteration takes longer, and flaky failures send the agent down wrong paths. Invest in containerized dev environments, parallel test execution, and environment-as-code.
+
+**3. Context management architecture**
+
+Design for multi-agent workflows from the start. This means hierarchical specification files (so agents at any level of the codebase get the right context), sub-agent definitions for repeatable specialized tasks (security review, migration, test writing), and clear conventions for how agents checkpoint state across sessions. Treat the `.claude/` directory with the same architectural rigor as your `terraform/` directory: it's infrastructure that determines how your AI agents operate.
+
+The formula from Part 1 bears repeating:
+
+**Specification quality x Loop autonomy x Context management = Reliable output at scale**
+
+Individual developers optimize all three intuitively: they write clear PRDs, let Ralph loops run overnight, and manage context by keeping projects small and focused. Enterprises need to do the same things systematically: clear specifications through SDD, autonomous execution through background agents and multi-agent teams, and context management through hierarchical configuration and sub-agent isolation.
+
+## The Process Must Run Autonomously
+
+The core argument of this series is that AI agents produce better output when they run autonomously against clear specifications than when humans guide them step-by-step. The evidence, from SWE-bench trajectories, from the Ralph community, from Cursor's background agents, from the productivity paradox research, points in the same direction. The [companion evidence paper](/papers/autonomous-agents/) synthesizes this data and is honest about the limits: autonomous output is not yet production-grade without human review, benchmark scores overstate real-world deployability, and perception frequently diverges from measured effects.
+
+But the directional signal is clear enough to act on. This isn't a minor optimization. It's a fundamental change in how software gets built. The developer's role shifts from writing code to writing specifications, from debugging implementation to reviewing holistic output, from managing a coding assistant to orchestrating an agent team.
+
+The enterprises that will lead in this transition are the ones that recognize the specification layer isn't optional overhead. It's the foundation that makes autonomous execution reliable. They'll invest in AGENTS.md before buying more Copilot licenses. They'll build SDD practices before deploying agent teams. They'll treat context management as a first-class architectural concern.
+
+And they'll let their agents run.
+
+---
+
+*This is Part 2 of a two-part series on scaling agentic development for enterprise teams. Part 1, [The Specification Layer](/articles/specification-layer/), covers why specifications and structured instructions are the missing enterprise scaling strategy.*
+
+*For the empirical evidence base, see [Autonomous AI Agents: Execution Loops vs Interactive Assistance](/papers/autonomous-agents/). For architectural analysis of the tools discussed here, see [Agentic Development Tools and Execution Architectures](/papers/agentic-tools/). For SDD framework comparisons, see [Spec-Driven Development Framework Patterns](/papers/sdd-frameworks/).*
+
+*This article is part of an ongoing research project tracking AI tooling, software engineering practices, and cross-functional workflows at [daviddaniel.tech/research](https://daviddaniel.tech/research).*
+
+---
+
+*This article was created with AI assistance. Sources include: METR developer productivity study (Becker et al., July 2025), SWE-bench benchmarks (OpenAI, August 2024; Vals AI and Scale AI leaderboards, accessed February 2026), Faros AI productivity data (July 2025), DORA 2024 and 2025 reports (Google Cloud), Stack Overflow 2025 Developer Survey, Anthropic C compiler experiment (Carlini, February 2026), and official tool documentation. Data as of February 2026.*

--- a/docs/articles/index.md
+++ b/docs/articles/index.md
@@ -1,0 +1,41 @@
+---
+title: Articles
+date: 2026-02-13
+description: Practitioner-focused articles on scaling agentic development, specification infrastructure, and autonomous execution patterns for enterprise teams.
+---
+
+# Articles
+
+Practitioner-focused analysis bridging research findings to enterprise adoption strategies.
+
+---
+
+### [The Specification Layer: Why Enterprises Can't Scale AI Development Without It](/articles/specification-layer/)
+
+Why explicit, machine-readable specifications are the missing infrastructure for scaling agentic development across enterprise teams. Covers AGENTS.md, CLAUDE.md, SDD frameworks, and the four-tier specification architecture.
+
+**Topics:** Specification layer, AGENTS.md, CLAUDE.md, SDD frameworks, enterprise scaling
+
+[Read →](/articles/specification-layer/)
+
+---
+
+### [The Autonomous Agents Loop: Why AI Agents Produce Better Output When You Stop Interrupting Them](/articles/autonomous-agents-loop/)
+
+Why autonomous AI execution loops outperform interactive assistance, and how enterprises can build the execution environment, context management, and multi-agent infrastructure to capture those gains.
+
+**Topics:** Autonomous execution, Ralph technique, multi-agent architecture, context management, Plan-Execute-Verify-Iterate
+
+[Read →](/articles/autonomous-agents-loop/)
+
+---
+
+## About
+
+These articles are companion pieces to the [research papers](/papers/), translating empirical findings into actionable guidance for engineering leaders and practitioners. They are part of a two-part series on scaling agentic development for enterprise teams.
+
+## Related Research
+
+- [Autonomous AI Agents: Execution Loops vs Interactive Assistance](/papers/autonomous-agents/) — the empirical evidence base
+- [Agentic Development Tools and Execution Architectures](/papers/agentic-tools/) — architectural analysis of the tools discussed
+- [Spec-Driven Development Framework Patterns](/papers/sdd-frameworks/) — framework comparison and adoption guidance

--- a/docs/articles/specification-layer/index.md
+++ b/docs/articles/specification-layer/index.md
@@ -1,0 +1,132 @@
+---
+title: "The Specification Layer: Why Enterprises Can't Scale AI Development Without It"
+description: Why explicit, machine-readable specifications are the missing infrastructure for scaling agentic development across enterprise teams. Covers AGENTS.md, CLAUDE.md, SDD frameworks, and the four-tier specification architecture.
+---
+
+# The Specification Layer: Why Enterprises Can't Scale AI Development Without It
+
+*Part 1 of 2: Scaling Agentic Development for Enterprise Teams*
+
+**Published:** February 2026 | **Author:** David Daniel
+
+---
+
+Individual developers are shipping features in 90 minutes that used to take days. The [Ralph technique](https://awesomeclaude.ai/ralph-wiggum), a bash loop that runs Claude Code against a product requirements document until all tasks pass, completed a $50,000 contract for $297 in API costs (self-reported, unaudited). Cursor's background agents execute multi-file refactors asynchronously while developers work on something else. [OpenClaw](https://github.com/nicepkg/openclaw) accumulated 145,000 GitHub stars within weeks following a viral launch in late January 2026 by giving an AI agent persistent access to a user's entire digital workspace.
+
+But when enterprise engineering leaders ask "how do we get that speed across 50 teams?", the honest answer is that most can't. Not yet. Not because the models aren't capable, but because their organizations are missing the layer that makes autonomous execution reliable: the specification layer.
+
+The individual developer advantage isn't raw AI capability. It's that a single person holds the full context of what "done" looks like in their head, and can course-correct an agent in real time. Enterprise teams don't have that luxury. They have distributed context, competing conventions, and dozens of engineers whose implicit knowledge never makes it into a document. When you hand an AI agent a vague prompt in that environment, you don't get speed. You get confidently wrong code at scale.
+
+The emerging evidence from early 2026 is clear: the teams seeing reliable, repeatable results from agentic development are the ones investing in explicit, machine-readable specifications that serve as the anchor for autonomous execution loops. The specification layer isn't overhead. It's the prerequisite for everything else.
+
+## What the Specification Layer Actually Is
+
+The specification layer is the collection of documents, configuration files, and structured instructions that tell AI agents *what* to build, *how* your team builds it, and *what "done" looks like*, persistently, across sessions, without a human repeating themselves.
+
+In practice, it's built from several components that have rapidly standardized over the past six months:
+
+**AGENTS.md** serves as the cross-agent standard, a vendor-neutral markdown file at the repository root that any AI coding agent can read. Launched by OpenAI in August 2025, it went from zero to over 20,000 repositories within weeks and now sits at 60,000+ open-source projects. It's supported by Codex, Cursor, GitHub Copilot's agent mode, Amp, Jules, and Factory. In December 2025, [OpenAI donated it to the Agentic AI Foundation](https://openai.com/index/agentic-ai-foundation/) under the Linux Foundation, signaling that the industry considers this foundational infrastructure. The OpenAI main repository alone contains [88 AGENTS.md files](https://agents.md), one per package in their monorepo, each with tailored instructions.
+
+**CLAUDE.md** is Claude Code's equivalent, read at the start of every session. Enterprise teams have begun treating it as critical infrastructure. One practitioner reports (in a community discussion) their professional monorepo's CLAUDE.md is 13KB, strictly maintained and subject to code review, documenting only tools and APIs used by 30 percent or more of their engineers. Less common tools go in product-specific markdown files deeper in the directory tree.
+
+**Spec-driven development (SDD) frameworks** provide the architectural layer above individual agent configuration. Three frameworks matured significantly in late 2025: Amazon's Kiro IDE implements specs-from-prompts with living documentation, GitHub's SpecKit provides agent-agnostic tooling for existing workflows, and OpenSpec offers a lightweight framework addressing context loss in "vibe coding." InfoQ positioned SDD as ["fifth-generation programming"](https://infoq.com/articles/spec-driven-development/) where specifications become executable. For a detailed comparison of SDD frameworks including BMAD, SpecKit, and OpenSpec, see the companion research paper [Spec-Driven Development Framework Patterns](/papers/sdd-frameworks/).
+
+**Custom agents and skills** (`.claude/agents/*.md`, `SKILL.md`) codify team expertise into reusable, version-controlled modules. Some repositories now contain over a hundred specialized agents with scores of skills and plugins. These aren't hobby projects. They encode security review checklists, deployment procedures, testing patterns, and architectural constraints as executable agent instructions.
+
+Together, these components form a specification layer that functions as an operating system for AI-assisted development. The code is the output. The specification layer is the program.
+
+## Why Autonomous Loops Need Specifications
+
+The most important pattern in agentic development is the recursive execution loop. The Ralph technique is the most visible example: run an agent against a specification, check if the output meets the spec, loop until it does. But the same pattern appears in every effective agentic workflow: Cursor's background agents running test suites and self-correcting, Claude Code's agent teams decomposing tasks and verifying results, Devin's multi-hour autonomous sessions with milestone-based progress.
+
+These loops produce dramatically better output than single-shot generation. SWE-bench data shows an order-of-magnitude improvement when the same model operates inside an agentic scaffold versus a non-agentic baseline — for example, GPT-4 improving from 2.7 percent on a RAG-based scaffold to 28.3 percent on CodeR ([OpenAI, August 2024](https://openai.com/index/introducing-swe-bench-verified/)). Frontier agentic systems reached 75 to 80 percent on SWE-bench Verified by late 2025, though contamination-resistant [SWE-bench Pro](https://scale.com/leaderboard/swe_bench_pro_public) results remain near 23 percent, suggesting headline scores overstate general real-world capability. For the full evidence base on autonomous loops versus interactive assistance, including methodology caveats, see [Autonomous AI Agents: Execution Loops vs Interactive Assistance](/papers/autonomous-agents/).
+
+But here's the problem that enterprises hit: recursive loops without a specification drift. Each iteration, the agent makes micro-decisions, variable naming, error handling patterns, API design choices, that compound. After ten iterations, the code works but doesn't match the team's conventions. After twenty, it's architecturally inconsistent with the rest of the codebase. After a hundred (which Ralph-style loops routinely reach), you have functional code that fails code review because it was built against the agent's training data, not your team's actual standards.
+
+The specification layer solves this by giving the loop a reference point that isn't the agent's own output. Each iteration checks not just "does it run?" but "does it match the spec?" Drift is detected and corrected because the specification defines success independently of the agent's internal state.
+
+This is why AGENTS.md and CLAUDE.md matter so much for enterprise adoption. They aren't just nice-to-have documentation. They're the anchor that makes autonomous execution loops converge on correct output instead of drifting toward plausible but wrong output.
+
+The ["Agentic Much?" study](https://arxiv.org/abs/2601.18341) (Robbes et al., January 2026), the first large-scale academic analysis of coding agent adoption across 129,134 GitHub projects, found that Claude Code and GitHub Copilot account for over half of detected agent adoption, with an average of 1.6+ agents per adopting project. But critically, they also found "silent adopters," repositories using agents without configuration files. Those silent adopters are the teams most likely to be experiencing the drift problem, because they're running agents without the specification layer. For more on how these tools differ architecturally in their approach to context management and governance, see [Agentic Development Tools and Execution Architectures](/papers/agentic-tools/).
+
+## The Evidence: Why Specifications Matter for Autonomous Output
+
+The evidence for investing in specification infrastructure comes from multiple independent sources that tell a consistent story, though with important caveats. For detailed analysis of each study's methodology and limitations, see [Autonomous AI Agents: Execution Loops vs Interactive Assistance](/papers/autonomous-agents/).
+
+**SWE-bench trajectory**: Agentic systems that implement plan-execute-verify-iterate loops against specifications consistently outperform single-shot systems. The order-of-magnitude improvement from agentic scaffolding is architectural, not just a function of model capability. However, the gap between Verified scores (75-80 percent) and contamination-resistant [Pro scores](https://scale.com/leaderboard/swe_bench_pro_public) (roughly 23 percent) warrants caution about headline claims.
+
+**The METR paradox, reframed**: The [METR RCT](https://metr.org/blog/2025-07-10-early-2025-ai-experienced-os-dev-study/) found experienced developers were 19 percent slower with interactive AI tools, despite believing they were faster. But this finding applies specifically to copilot-style assistance: short, interactive, specification-free interactions. The study authors note that results may not generalize to settings with autonomous loops or greenfield projects. [METR's follow-up](https://metr.org/blog/2025-08-12-research-update-towards-reconciling-slowdown-with-time-horizons/) found that while 38 percent of autonomous agent PRs (Claude 3.7 Sonnet in an agentic scaffold) passed automated tests, manual review of a subset found none were mergeable without human modification. The emerging counter-evidence from teams using specification-driven autonomous loops suggests the paradox may resolve when the interaction model shifts from "human drives, AI assists" to "human specifies, AI executes autonomously, human reviews."
+
+**Industry telemetry**: [Faros AI data](https://faros.ai/blog/ai-software-engineering) shows 21 percent more tasks completed but 91 percent longer review times under high AI adoption (vendor-sponsored study). This is the signature of agents running without adequate specifications. They produce more code, but the code requires more review because it doesn't consistently match expectations. The review burden is a symptom of specification debt.
+
+**The DORA findings**: The [2024 DORA report](https://cloud.google.com/blog/products/devops-sre/announcing-the-2024-accelerate-state-of-devops-report) established that AI adoption correlated negatively with both throughput and delivery stability. The [2025 report](https://cloud.google.com/blog/products/ai-machine-learning/announcing-the-2025-dora-report) found that the throughput correlation reversed to positive, but instability persisted. Its conclusion: "AI doesn't fix a team; it amplifies what's already there." Teams that had invested in specification infrastructure showed continued improvement. The implication: the specification layer is what determines whether AI amplifies good practices or bad ones.
+
+## What the Specification Layer Looks Like in Practice
+
+For an enterprise team adopting agentic development, the specification layer has four tiers:
+
+**Tier 1: Repository-level context** (AGENTS.md / CLAUDE.md at the root)
+
+This is the minimum viable specification. It tells every agent, regardless of vendor, how the project is structured, what the tech stack is, and what commands to run. It should be concise (the context window budget is real), universally applicable, and version-controlled.
+
+What to include: project purpose, directory structure, tech stack, build/test/lint commands, coding conventions that a linter can't enforce, and a pointer to deeper documentation. What to leave out: anything a linter or formatter handles deterministically, anything that only applies to specific subsystems (put that in nested files).
+
+**Tier 2: Package-level specialization** (nested AGENTS.md / CLAUDE.md per module)
+
+In monorepos, each package needs tailored instructions. The authentication module has different security constraints than the analytics dashboard. Nested specification files override parent files, so agents automatically get the right context for the code they're modifying. This pattern maps directly to the hierarchical context management strategies discussed in the [agentic tools analysis](/papers/agentic-tools/comparative-analysis#context-management-analysis).
+
+**Tier 3: Task-level specifications** (SDD specs, PRDs, acceptance criteria)
+
+This is where the specification layer connects to the execution loop. A well-written task spec defines what "done" looks like in terms the agent can verify: "the endpoint returns 200 with the correct JSON schema," "all existing tests pass," "the migration is reversible." These specs become the exit condition for autonomous loops.
+
+**Tier 4: Expertise codification** (.claude/agents/, SKILL.md, slash commands)
+
+This is the most sophisticated tier: encoding team expertise as reusable agent modules. A security review agent that embodies your team's threat modeling checklist. A migration agent that knows your database conventions. A test-writing agent that follows your team's testing philosophy. These are version-controlled, transferable between projects, and composable.
+
+## The Multi-Agent Architecture Connection
+
+Specifications become even more critical when you move from single-agent to multi-agent architectures. Claude Code's agent teams feature (Opus 4.6, February 2026) allows a primary agent to spawn specialized sub-agents for parallel execution. Goose's MCP integration enables extensible tool chains. Cursor's background agents run asynchronously in cloud sandboxes. For architectural detail on how these tools implement multi-context delegation differently, see the [tool analysis](/papers/agentic-tools/tool-analysis) in the agentic tools paper.
+
+In a multi-agent setup, each sub-agent operates in its own context window. Without a shared specification, these agents produce inconsistent output: one agent names variables in camelCase while another uses snake_case, one handles errors with try/catch while another uses Result types. The specification layer provides the common reference that keeps parallel agents aligned.
+
+This is the same principle that makes human engineering teams work: shared coding standards, architecture decision records, and style guides. The difference is that AI agents follow specifications more literally and consistently than human engineers, but only if those specifications exist and are machine-readable.
+
+## The Enterprise Scaling Formula
+
+The formula that's emerging from the most effective agentic development teams:
+
+**Specification quality x Loop autonomy x Context management = Reliable output at scale**
+
+Each variable matters:
+
+- **Specification quality** determines the ceiling. Vague specs produce vague code. Precise specs with verifiable acceptance criteria enable tight feedback loops.
+- **Loop autonomy** determines the speed. Agents that can plan, execute, test, and iterate without human intervention at each step produce more consistent output and free engineers for higher-value work. The [evidence base](/papers/autonomous-agents/) shows order-of-magnitude benchmark improvements from autonomous scaffolding.
+- **Context management** determines the sustainability. Multi-agent architectures, context compaction, checkpoint/resume patterns, and hierarchical specification files keep the system coherent as complexity grows.
+
+The teams that are seeing individual-developer speed at enterprise scale are the ones that have invested in all three. The teams that bought AI coding licenses without building the specification layer are the ones reporting the productivity paradox: more code, more review burden, net unclear benefit.
+
+## What This Means for Engineering Leaders
+
+The specification layer is not optional infrastructure for enterprises that want to scale agentic development. It's the foundation. And the [directional evidence](/papers/autonomous-agents/conclusions#9-conclusion-structured-autonomy-and-the-case-for-investment-now) is strong enough that building this infrastructure now, before autonomous output crosses the production-readiness threshold, is a strategic advantage.
+
+**Start with AGENTS.md.** It's the lowest-friction entry point: a single markdown file at the repository root that immediately improves agent output for every tool your team uses. The cross-agent standard means you're not locked into any vendor.
+
+**Treat CLAUDE.md (or your agent-specific equivalent) as production infrastructure.** It should be code-reviewed, concise, and maintained with the same rigor as your CI/CD configuration. A bloated CLAUDE.md degrades agent performance. A well-maintained one compounds in value over time.
+
+**Invest in SDD frameworks before investing in more agent licenses.** The bottleneck is rarely model capability. It's specification quality. Teams with clear specs and mediocre agents outperform teams with frontier models and vague prompts. For guidance on choosing between frameworks, see the [decision matrix](/papers/sdd-frameworks/frameworks-comparison#decision-matrix) in the SDD frameworks paper.
+
+**Build toward multi-agent architectures with shared specification layers.** The speed gains from autonomous loops compound when multiple agents can work in parallel, anchored to the same specifications. This is where the enterprise advantage kicks in: large teams with well-documented conventions can encode that knowledge into reusable agent modules in ways that individual developers can't.
+
+The individual developers at the forefront of this shift have already figured this out, even if they don't use the word "specification." Every Ralph loop starts with a PRD. Every effective CLAUDE.md is a specification. Every .claude/agents/ directory is a codified expertise library. The enterprise opportunity is to do this systematically, at scale, with the rigor that large organizations are uniquely positioned to bring.
+
+---
+
+*Part 2, [The Autonomous Agents Loop](/articles/autonomous-agents-loop/), explores the execution patterns, recursive loops, multi-agent orchestration, and context management, that turn specifications into shipped software.*
+
+*For the empirical evidence base supporting autonomous execution loops, see [Autonomous AI Agents: Execution Loops vs Interactive Assistance](/papers/autonomous-agents/).*
+
+*This article is part of an ongoing research project tracking AI tooling, software engineering practices, and cross-functional workflows at [daviddaniel.tech/research](https://daviddaniel.tech/research). For architectural analysis of the tools discussed here, see [Agentic Development Tools and Execution Architectures](/papers/agentic-tools/). For SDD framework comparisons, see [Spec-Driven Development Framework Patterns](/papers/sdd-frameworks/).*
+
+---
+
+*This article was created with AI assistance. Sources include: METR developer productivity study, DORA 2024 and 2025 reports, Faros AI productivity data, SWE-bench benchmarks, "Agentic Much?" (Robbes et al., January 2026), AGENTS.md specification, and official framework repositories. Data as of February 2026.*

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,43 +1,51 @@
 ---
 layout: home
-title: Research Papers - Technical Analysis on Software Development
+title: Research Papers & Articles - Technical Analysis on Software Development
 description: In-depth technical analysis on software development frameworks, AI-powered development tools, and engineering practices for architects and engineering professionals.
 
 hero:
-  name: Research Papers
+  name: Research Papers & Articles
   text: Technical Analysis & Guides
   tagline: In-depth analysis on software development frameworks, AI-powered development, and engineering practices
   actions:
     - theme: brand
+      text: Browse Articles
+      link: /articles/
+    - theme: alt
       text: Browse Papers
       link: /papers/
 
 features:
-  - title: Spec-Driven Development
-    details: Comprehensive analysis of enterprise-grade SDD frameworks including BMAD, SpecKit, and OpenSpec
-    link: /papers/sdd-frameworks/
+  - title: The Specification Layer
+    details: Why enterprises need explicit, machine-readable specifications to scale agentic development across teams
+    link: /articles/specification-layer/
+  - title: The Autonomous Agents Loop
+    details: Why AI agents produce better output when they run autonomously against clear specifications
+    link: /articles/autonomous-agents-loop/
+  - title: Autonomous AI Agents
+    details: Evidence synthesis on execution loops vs interactive assistance, covering SWE-bench, METR, and industry telemetry
+    link: /papers/autonomous-agents/
   - title: Agentic Development Tools
     details: Architectural comparison of Claude Code, Goose, Cursor, and GitHub Copilot
     link: /papers/agentic-tools/
-  - title: Practical Focus
-    details: Implementation guidance and comparisons based on hands-on experience
+  - title: Spec-Driven Development
+    details: Comprehensive analysis of enterprise-grade SDD frameworks including BMAD, SpecKit, and OpenSpec
+    link: /papers/sdd-frameworks/
 ---
 
 ## What's Here
 
 Technical analysis designed for software architects, principal engineers, and development team leads evaluating modern frameworks and tools.
 
-Each paper provides:
+**Articles** provide practitioner-focused guidance on scaling agentic development for enterprise teams.
 
-- Framework comparisons and architectural analysis
-- Practical implementation patterns
-- Integration guidance
-- Real-world adoption considerations
+**Papers** provide in-depth empirical analysis with framework comparisons, architectural patterns, and evidence synthesis.
 
 ## Navigation
 
-- **[Papers](/papers/)** - Browse all papers
+- **[Articles](/articles/)** - Practitioner-focused articles
+- **[Papers](/papers/)** - Research papers
 
 ---
 
-*All content created with AI assistance. See individual papers for specific sources.*
+*All content created with AI assistance. See individual papers and articles for specific sources.*

--- a/docs/papers/index.md
+++ b/docs/papers/index.md
@@ -40,6 +40,13 @@ Analysis of BMAD, SpecKit, and OpenSpec frameworks - when to use each, how they 
 
 ---
 
+## Companion Articles
+
+These papers are supported by practitioner-focused articles in the [Articles](/articles/) section:
+
+- [The Specification Layer](/articles/specification-layer/) — why enterprises need machine-readable specifications to scale agentic development
+- [The Autonomous Agents Loop](/articles/autonomous-agents-loop/) — why autonomous execution loops outperform interactive assistance
+
 ## About
 
 These papers are:


### PR DESCRIPTION
## Summary

- Adds the **Autonomous AI Agents** research paper (execution loops vs interactive assistance) with evidence synthesis covering SWE-bench, METR RCT, industry telemetry, and adjacent domains
- Adds two companion **articles** as a two-part series on scaling agentic development for enterprise teams:
  - **The Specification Layer** — why enterprises need machine-readable specifications (AGENTS.md, CLAUDE.md, SDD frameworks, four-tier architecture)
  - **The Autonomous Agents Loop** — why autonomous execution loops outperform interactive assistance (Ralph technique, Plan-Execute-Verify-Iterate, multi-agent architecture, context management)
- Adds Articles section with index page, navigation, sidebar, and structured data
- Updates landing page (renamed to "Research Papers & Articles"), top nav ("Research"), and papers index with cross-references
- Fixes internal links from articles to use correct published paper path (`/papers/autonomous-agents/`)
- Removes dead link ignore for `/articles/` now that they exist
- Includes RSS feed support, SEO improvements, and various prior enhancements from earlier commits on this branch

## Test plan

- [x] `npm run docs:build` succeeds with no errors
- [x] All internal cross-references verified (articles ↔ papers, anchor links to specific sections)
- [x] No remaining references to deprecated `/papers/autonomous-loops/` path
- [ ] Verify navigation renders correctly (Home, Articles, Papers)
- [ ] Verify article sidebar shows both articles in series
- [ ] Verify landing page feature cards link correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)