### PR TITLE
fix(seo): resolve indexing blockers and metadata hygiene

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-This is a technical research repository hosting comprehensive research papers on software development frameworks, AI-powered development, and modern engineering practices. The repository uses VitePress to publish professional documentation at https://davidedaniel.github.io/research/.
+This is a technical research repository hosting comprehensive research papers on software development frameworks, AI-powered development, and modern engineering practices. The repository uses VitePress to publish professional documentation at https://daviddaniel.tech/research/.
 
 ## Repository Purpose
 
@@ -176,7 +176,7 @@ What readers will learn.
 ### Deployment
 - Automatic via GitHub Actions on push to `main`
 - Workflow: `.github/workflows/deploy.yml`
-- Live site: https://davidedaniel.github.io/research/
+- Live site: https://daviddaniel.tech/research/
 - Build time: 2-3 minutes
 
 ## Content Guidelines for AI Assistants
@@ -220,6 +220,7 @@ Every markdown file must include YAML frontmatter with:
 ---
 title: Page Title (50-60 characters ideal)
 description: Page description for meta tags (150-160 characters ideal)
+date: YYYY-MM-DD publication date
 ---
 ```
 
@@ -228,6 +229,7 @@ Example for paper pages:
 ---
 title: Spec-Driven Development Framework Patterns
 description: Comprehensive analysis of BMAD, SpecKit, and OpenSpec frameworks for specification-driven development. Includes framework comparison and adoption guidance.
+date: 2026-01-07
 ---
 ```
 
@@ -250,15 +252,23 @@ The VitePress config (`docs/.vitepress/config.js`) automatically generates:
 When creating new pages:
 1. Add `title` frontmatter (required)
 2. Add `description` frontmatter (required, 150-160 chars)
-3. Use descriptive H1 heading (should match or relate to title)
-4. Include internal links to related content
-5. Verify page appears in sitemap after build
+3. Add `date` frontmatter (required, ISO format `YYYY-MM-DD`)
+4. Use descriptive H1 heading (should match or relate to title)
+5. Include internal links to related content
+6. Verify page appears in sitemap after build
+
+### SEO Validation (Post-Build)
+
+- Verify `sitemap.xml` contains all expected page URLs
+- Verify no page has duplicate canonical tags in rendered HTML
+- Verify structured data dates come from frontmatter, not hardcoded values
 
 ### Sitemap and Robots
 
 - Sitemap: Auto-generated at `/research/sitemap.xml`
 - Robots.txt: Located at `docs/public/robots.txt`
 - Both are configured and should not need manual updates
+- Note: robots.txt deploys to `/research/robots.txt` due to VitePress base path. The sitemap is submitted directly via Google Search Console to work around this.
 
 ### SEO Files Reference
 
@@ -309,11 +319,11 @@ Potential topics for expansion:
 ## Current Tasks and Next Steps
 
 ### Immediate (Now)
-- [ ] Push repository to GitHub
-- [ ] Enable GitHub Pages
-- [ ] Verify deployment successful
-- [ ] Test all navigation links
-- [ ] Confirm search functionality
+- [x] Push repository to GitHub
+- [x] Enable GitHub Pages
+- [x] Verify deployment successful
+- [x] Test all navigation links
+- [x] Confirm search functionality
 
 ### Short-term (This Month)
 - [ ] Add paper navigation improvements

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A collection of technical research papers and documentation on software developm
 ### Spec-Driven Development Frameworks (January 2026)
 Comprehensive analysis of enterprise-grade specification-driven development frameworks including BMAD, SpecKit, and OpenSpec. Covers foundational theory, framework comparisons, and ecosystem integration.
 
-[Read the paper →](https://davidedaniel.github.io/research/papers/sdd-frameworks/)
+[Read the paper →](https://daviddaniel.tech/research/papers/sdd-frameworks/)
 
 ## About This Repository
 
@@ -15,7 +15,7 @@ This repository contains in-depth technical research aimed at software architect
 
 ## Documentation Site
 
-Visit the full documentation site: [davidedaniel.github.io/research](https://davidedaniel.github.io/research/)
+Visit the full documentation site: [daviddaniel.tech/research](https://daviddaniel.tech/research/)
 
 ## Building Locally
 

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -61,17 +61,16 @@ export default withMermaid(
       ['meta', { name: 'keywords', content: 'spec-driven development, software architecture, development frameworks, BDD, contract testing, agentic tools, AI development, Claude Code, Cursor' }],
       ['meta', { name: 'robots', content: 'index, follow' }],
 
-      // Canonical base (pages will override with specific URLs)
-      ['link', { rel: 'canonical', href: `${siteUrl}/` }],
-
       // Open Graph base tags
       ['meta', { property: 'og:site_name', content: siteName }],
       ['meta', { property: 'og:type', content: 'website' }],
       ['meta', { property: 'og:locale', content: 'en_US' }],
+      ['meta', { property: 'og:image', content: `${siteUrl}/og-image.svg` }],
 
       // Twitter card base tags
       ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
       ['meta', { name: 'twitter:site', content: '@davidedaniel' }],
+      ['meta', { name: 'twitter:image', content: `${siteUrl}/og-image.svg` }],
 
       // Theme color
       ['meta', { name: 'theme-color', content: '#3eaf7c' }],
@@ -87,7 +86,15 @@ export default withMermaid(
         .replace(/\.md$/, '')
 
       // Build page-specific head tags
-      const head = pageData.frontmatter.head || []
+      const head = (pageData.frontmatter.head || []).filter((tag) => {
+        return !(tag[0] === 'link' && tag[1]?.rel === 'canonical')
+      })
+
+      const formatDateToIso = (value) => {
+        if (!value) return null
+        const parsed = new Date(value)
+        return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString().split('T')[0]
+      }
 
       // Add canonical URL
       head.push(['link', { rel: 'canonical', href: canonicalUrl }])
@@ -108,6 +115,8 @@ export default withMermaid(
       const isPaperPage = pageData.relativePath.includes('papers/') && !pageData.relativePath.endsWith('papers/index.md')
       const isArticlePage = pageData.relativePath.includes('articles/') && !pageData.relativePath.endsWith('articles/index.md')
       if (isPaperPage || isArticlePage) {
+        const datePublished = formatDateToIso(pageData.frontmatter.date) || '2026-01-01'
+        const dateModified = formatDateToIso(pageData.lastUpdated) || datePublished
         const structuredData = {
           '@context': 'https://schema.org',
           '@type': 'TechArticle',
@@ -122,8 +131,8 @@ export default withMermaid(
             name: 'David Daniel'
           },
           url: canonicalUrl,
-          datePublished: '2026-01-01',
-          dateModified: new Date().toISOString().split('T')[0]
+          datePublished,
+          dateModified
         }
 
         head.push([

--- a/docs/articles/autonomous-agents-loop/index.md
+++ b/docs/articles/autonomous-agents-loop/index.md
@@ -1,5 +1,6 @@
 ---
 title: "The Autonomous Agents Loop: Why AI Agents Produce Better Output When You Stop Interrupting Them"
+date: 2026-02-13
 description: Why autonomous AI execution loops outperform interactive assistance, and how enterprises can build the execution environment, context management, and multi-agent infrastructure to capture those gains.
 ---
 
@@ -148,6 +149,12 @@ And they'll let their agents run.
 *For the empirical evidence base, see [Autonomous AI Agents: Execution Loops vs Interactive Assistance](/papers/autonomous-agents/). For architectural analysis of the tools discussed here, see [Agentic Development Tools and Execution Architectures](/papers/agentic-tools/). For SDD framework comparisons, see [Spec-Driven Development Framework Patterns](/papers/sdd-frameworks/).*
 
 *This article is part of an ongoing research project tracking AI tooling, software engineering practices, and cross-functional workflows at [daviddaniel.tech/research](https://daviddaniel.tech/research).*
+
+## Related Content
+
+- [Autonomous Agents](/papers/autonomous-agents/) - Evidence synthesis on when autonomous loops beat interactive assistance and where limits remain.
+- [Agentic Tools](/papers/agentic-tools/) - Tool architecture comparison across Claude Code, Goose, Cursor, and GitHub Copilot.
+- [Part 1: The Specification Layer](/articles/specification-layer/) - Why machine-readable specifications are prerequisite infrastructure for reliable loops.
 
 ---
 

--- a/docs/articles/specification-layer/index.md
+++ b/docs/articles/specification-layer/index.md
@@ -1,5 +1,6 @@
 ---
 title: "The Specification Layer: Why Enterprises Can't Scale AI Development Without It"
+date: 2026-02-13
 description: Why explicit, machine-readable specifications are the missing infrastructure for scaling agentic development across enterprise teams. Covers AGENTS.md, CLAUDE.md, SDD frameworks, and the four-tier specification architecture.
 ---
 
@@ -126,6 +127,12 @@ The individual developers at the forefront of this shift have already figured th
 *For the empirical evidence base supporting autonomous execution loops, see [Autonomous AI Agents: Execution Loops vs Interactive Assistance](/papers/autonomous-agents/).*
 
 *This article is part of an ongoing research project tracking AI tooling, software engineering practices, and cross-functional workflows at [daviddaniel.tech/research](https://daviddaniel.tech/research). For architectural analysis of the tools discussed here, see [Agentic Development Tools and Execution Architectures](/papers/agentic-tools/). For SDD framework comparisons, see [Spec-Driven Development Framework Patterns](/papers/sdd-frameworks/).*
+
+## Related Content
+
+- [SDD Frameworks](/papers/sdd-frameworks/) - Comprehensive comparison of BMAD, SpecKit, and OpenSpec for enterprise specification workflows.
+- [Agentic Tools](/papers/agentic-tools/) - Architectural analysis of execution models, autonomy boundaries, and governance tradeoffs.
+- [Part 2: The Autonomous Agents Loop](/articles/autonomous-agents-loop/) - Why uninterrupted plan-execute-verify-iterate loops improve agent output quality.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,7 @@
 ---
 layout: home
-title: Research Papers & Articles - Technical Analysis on Software Development
+title: Spec-Driven Development & Agentic AI Tools Research
+date: 2026-02-13
 description: In-depth technical analysis on software development frameworks, AI-powered development tools, and engineering practices for architects and engineering professionals.
 
 hero:

--- a/docs/papers/agentic-tools/index.md
+++ b/docs/papers/agentic-tools/index.md
@@ -139,6 +139,11 @@ This paper will be updated periodically to reflect:
 
 **Next Scheduled Review:** April 2026
 
+## Related Content
+
+- [The Autonomous Agents Loop](/articles/autonomous-agents-loop/) - Practical execution-loop patterns for turning specifications into shipped code.
+- [SDD Frameworks](/papers/sdd-frameworks/) - Framework-level guidance for specification governance across teams and repositories.
+
 ---
 
 *This research was created with AI assistance. Tools analyzed: Claude Code, Goose, Cursor, and GitHub Copilot from official documentation and public materials. Data as of January 2026.*

--- a/docs/papers/autonomous-agents/adjacent-domains.md
+++ b/docs/papers/autonomous-agents/adjacent-domains.md
@@ -1,5 +1,6 @@
 ---
 title: Adjacent Domains and Mechanisms
+date: 2026-02-01
 description: Evidence for autonomous iteration advantages from game AI, autonomous driving, and medical screening, plus analysis of interruption costs and scaling laws.
 ---
 

--- a/docs/papers/autonomous-agents/benchmarks.md
+++ b/docs/papers/autonomous-agents/benchmarks.md
@@ -1,5 +1,6 @@
 ---
 title: SWE-bench and Multi-Agent Execution
+date: 2026-02-01
 description: Analysis of SWE-bench benchmark results showing how agentic scaffolding produces order-of-magnitude improvements, plus the Anthropic C compiler multi-agent experiment.
 ---
 

--- a/docs/papers/autonomous-agents/conclusions.md
+++ b/docs/papers/autonomous-agents/conclusions.md
@@ -1,5 +1,6 @@
 ---
 title: Conclusions and References
+date: 2026-02-01
 description: Where autonomous loops outperform interactive assistance and where they fall short, the case for investing in infrastructure now, and complete reference list.
 ---
 

--- a/docs/papers/autonomous-agents/index.md
+++ b/docs/papers/autonomous-agents/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Autonomous AI Agents: Execution Loops vs Interactive Assistance"
+date: 2026-02-01
 description: Evidence synthesis comparing autonomous AI agent execution loops against interactive human-in-the-loop assistance. Covers SWE-bench benchmarks, the METR RCT, industry telemetry, adjacent domain evidence, and mechanisms.
 ---
 
@@ -47,6 +48,11 @@ For architectural analysis of the tools that implement these patterns, see [Agen
 - Autonomous agent PRs that pass automated tests still fail human code review standards
 - Adjacent domains (game AI, autonomous driving, medical screening) confirm autonomous iteration advantages under specific conditions
 - The defensible operational position is structured autonomy with automated verification, not unsupervised deployment
+
+## Related Content
+
+- [The Autonomous Agents Loop](/articles/autonomous-agents-loop/) - Implementation patterns for running long autonomous plan-execute-verify cycles in practice.
+- [Agentic Tools](/papers/agentic-tools/) - Architectural comparison of tools that host and govern autonomous coding workflows.
 
 ---
 

--- a/docs/papers/autonomous-agents/productivity-evidence.md
+++ b/docs/papers/autonomous-agents/productivity-evidence.md
@@ -1,5 +1,6 @@
 ---
 title: Developer Productivity Evidence
+date: 2026-02-01
 description: Analysis of the METR RCT, Faros AI telemetry, Stack Overflow survey data, and DORA reports on real-world developer productivity with AI tools.
 ---
 

--- a/docs/papers/index.md
+++ b/docs/papers/index.md
@@ -1,6 +1,6 @@
 ---
 title: Research Papers
-date: 2026-01-07
+date: 2026-02-01
 description: Browse technical research papers on spec-driven development, agentic tools, software architecture, and modern engineering practices.
 ---
 

--- a/docs/papers/sdd-frameworks/index.md
+++ b/docs/papers/sdd-frameworks/index.md
@@ -247,6 +247,11 @@ Daniel, David (2026). Spec-Driven Development Framework Patterns.
 Retrieved from https://davidedaniel.github.io/research/papers/sdd-frameworks/
 ```
 
+## Related Content
+
+- [The Specification Layer](/articles/specification-layer/) - Why explicit specifications are the operational foundation for enterprise-scale agentic development.
+- [Agentic Tools](/papers/agentic-tools/) - Comparative analysis of execution architectures used to run specification-driven workflows.
+
 ---
 
 *This research was created with AI assistance. Frameworks analyzed: BMAD, SpecKit, and OpenSpec from official GitHub repositories. Theoretical foundations derived from TDD, BDD, and CDC literature. Ecosystem analysis includes MetaGPT, Momentic, Pact, Cucumber, and related technologies as of January 2026.*

--- a/docs/public/og-image.svg
+++ b/docs/public/og-image.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">Research Papers and Articles</title>
+  <desc id="desc">Default social sharing image for daviddaniel.tech research site</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#141428"/>
+      <stop offset="100%" stop-color="#1f2b4a"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <rect x="80" y="80" width="1040" height="470" rx="18" fill="none" stroke="#4d5d8a" stroke-width="2" opacity="0.75"/>
+  <text x="110" y="285" fill="#ffffff" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif" font-size="68" font-weight="700" letter-spacing="0.5">
+    Research Papers &amp; Articles
+  </text>
+  <text x="110" y="350" fill="#c7d2f0" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif" font-size="34" font-weight="400">
+    daviddaniel.tech/research
+  </text>
+</svg>


### PR DESCRIPTION
- remove duplicate canonical tag source and keep per-page canonical

- source structured-data dates from frontmatter/lastUpdated

- add default OG image and global og/twitter image tags

- add missing frontmatter dates across docs pages

- add related-content internal cross-links on papers/articles

- update homepage SEO title and docs domain references

- expand SEO validation guidance in CLAUDE.md