### PR TITLE
Enhance SEO with dynamic og:type, structured data, and author metadata

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,9 +208,28 @@ flowchart TD
 
 Use `<br/>` for line breaks within node labels. Prefer `flowchart TD` (top-down) for hierarchical diagrams.
 
-## SEO Requirements
+## Content Policy (CRITICAL)
+
+- NEVER modify existing markdown body content, prose, headings, research text, or any visible text without explicit user approval
+- Frontmatter YAML changes (between `---` fences) are safe for metadata fields
+- VitePress config changes for `<head>` injection are safe
+- Treat all markdown body content below the frontmatter as frozen
+- If unsure whether a change affects visible content, ask before proceeding
+
+## SEO Requirements (MANDATORY -- do not regress)
 
 All pages must follow SEO best practices to ensure proper indexing and discoverability.
+
+### Critical Invariants
+
+- `docs/public/robots.txt` must exist and must NOT contain `Disallow: /`
+- VitePress sitemap generation must be enabled with `hostname: 'https://daviddaniel.tech'`
+- All canonical URLs must use `https://daviddaniel.tech/research/` -- NEVER `davidedaniel.github.io/research/`
+- Every page must have exactly ONE canonical tag (no duplicates from global + per-page config conflicts)
+- Every `.md` file in `docs/papers/` and `docs/articles/` must have frontmatter with: `title`, `description`, `author`, `date`
+- JSON-LD structured data must be maintained via `transformPageData` (TechArticle for papers/articles, WebPage for index pages, BreadcrumbList for all pages)
+- `titleTemplate` must include "David Daniel Research" for branding
+- When adding new pages: add frontmatter with all required fields, verify sitemap includes the new page, verify canonical URL is correct
 
 ### Frontmatter Requirements (Mandatory)
 
@@ -220,6 +239,7 @@ Every markdown file must include YAML frontmatter with:
 ---
 title: Page Title (50-60 characters ideal)
 description: Page description for meta tags (150-160 characters ideal)
+author: David Daniel
 date: YYYY-MM-DD (publication date, used in structured data)
 ---
 ```
@@ -229,6 +249,7 @@ Example for paper pages:
 ---
 title: Spec-Driven Development Framework Patterns
 description: Comprehensive analysis of BMAD, SpecKit, and OpenSpec frameworks for specification-driven development. Includes framework comparison and adoption guidance.
+author: David Daniel
 date: 2026-01-07
 ---
 ```
@@ -243,18 +264,21 @@ date: 2026-01-07
 
 The VitePress config (`docs/.vitepress/config.js`) automatically generates:
 - Canonical URLs per page
-- Open Graph tags (`og:title`, `og:description`, `og:url`)
+- Open Graph tags (`og:title`, `og:description`, `og:url`, `og:type`)
 - Twitter card tags
-- JSON-LD structured data for paper pages (TechArticle schema)
+- JSON-LD structured data (TechArticle for papers/articles, WebPage for index pages, BreadcrumbList for all pages)
+- Dynamic `og:type` (`article` for papers/articles, `website` for other pages)
 
 ### SEO Checklist for New Pages
 
 When creating new pages:
 1. Add `title` frontmatter (required)
 2. Add `description` frontmatter (required, 150-160 chars)
-3. Use descriptive H1 heading (should match or relate to title)
-4. Include internal links to related content
-5. Verify page appears in sitemap after build
+3. Add `author: David Daniel` frontmatter (required)
+4. Add `date` frontmatter (required, YYYY-MM-DD)
+5. Use descriptive H1 heading (should match or relate to title)
+6. Include internal links to related content
+7. Verify page appears in sitemap after build
 
 ### Sitemap and Robots
 
@@ -267,16 +291,21 @@ When creating new pages:
 
 | File | Purpose |
 |------|---------|
-| `docs/.vitepress/config.js` | Sitemap config, meta tags, transformPageData hook |
+| `docs/.vitepress/config.js` | Sitemap config, meta tags, transformPageData hook, JSON-LD structured data |
 | `docs/public/robots.txt` | Search engine crawler instructions |
-| Page frontmatter | Per-page title, description, and date |
+| Page frontmatter | Per-page title, description, author, and date |
 
-### SEO Validation (Post-Build)
+### Build Verification
 
-After running `npm run docs:build`, verify:
-- `sitemap.xml` in `docs/.vitepress/dist/` contains all expected page URLs with correct `https://daviddaniel.tech/research/` prefix
-- No page in `docs/.vitepress/dist/` has duplicate `<link rel="canonical">` tags in rendered HTML
+After any config change, run: `npm run docs:build`
+
+Check built HTML for:
+- Exactly one `<link rel="canonical">` tag per page with correct `daviddaniel.tech` URL
+- Valid `sitemap.xml` present in `docs/.vitepress/dist/`
+- `robots.txt` present in `docs/.vitepress/dist/`
+- No HTML file references `davidedaniel.github.io`
 - Structured data `datePublished` and `dateModified` values come from frontmatter `date` and `lastUpdated`, not hardcoded values
+- JSON-LD blocks present for TechArticle (papers/articles), WebPage (index pages), and BreadcrumbList (all pages)
 
 ## Future Paper Ideas
 

--- a/SETUP_INSTRUCTIONS.md
+++ b/SETUP_INSTRUCTIONS.md
@@ -61,13 +61,13 @@ git push origin main
 
 1. Go to repository Actions tab
 2. Wait for "Deploy VitePress site to Pages" workflow to complete
-3. Once complete, visit: https://davidedaniel.github.io/research/
+3. Once complete, visit: https://daviddaniel.tech/research/
 
 ## Step 5: Update Repository Settings (Optional)
 
 1. Go to repository Settings
 2. Add topics: `research`, `documentation`, `spec-driven-development`, `software-architecture`
-3. Set website URL: https://davidedaniel.github.io/research/
+3. Set website URL: https://daviddaniel.tech/research/
 4. Add description and tags as needed
 
 ## Local Development
@@ -148,7 +148,7 @@ research/
 
 After setup is complete:
 
-1. Review live site at https://davidedaniel.github.io/research/
+1. Review live site at https://daviddaniel.tech/research/
 2. Test all navigation links
 3. Verify search functionality works
 4. Check mobile responsiveness

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -26,6 +26,7 @@ export default withMermaid(
   defineConfig({
     title: siteName,
     description: siteDescription,
+    titleTemplate: ':title | David Daniel Research',
     base: '/research/',
 
     // Sitemap configuration
@@ -62,8 +63,7 @@ export default withMermaid(
       ['meta', { name: 'robots', content: 'index, follow' }],
 
       // Open Graph base tags
-      ['meta', { property: 'og:site_name', content: siteName }],
-      ['meta', { property: 'og:type', content: 'website' }],
+      ['meta', { property: 'og:site_name', content: 'David Daniel Research' }],
       ['meta', { property: 'og:locale', content: 'en_US' }],
 
       // Twitter card base tags
@@ -93,21 +93,26 @@ export default withMermaid(
       // Add canonical URL
       head.push(['link', { rel: 'canonical', href: canonicalUrl }])
 
-      // Add Open Graph tags
+      // Page metadata
       const title = pageData.frontmatter.title || pageData.title || siteName
       const description = pageData.frontmatter.description || siteDescription
 
+      // Determine page type
+      const isPaperPage = pageData.relativePath.includes('papers/') && !pageData.relativePath.endsWith('papers/index.md')
+      const isArticlePage = pageData.relativePath.includes('articles/') && !pageData.relativePath.endsWith('articles/index.md')
+      const isContentPage = isPaperPage || isArticlePage
+
+      // Open Graph tags (og:type is dynamic: 'article' for individual papers/articles, 'website' for listing/index pages)
       head.push(['meta', { property: 'og:title', content: title }])
       head.push(['meta', { property: 'og:description', content: description }])
       head.push(['meta', { property: 'og:url', content: canonicalUrl }])
+      head.push(['meta', { property: 'og:type', content: isContentPage ? 'article' : 'website' }])
 
       // Twitter card tags
       head.push(['meta', { name: 'twitter:title', content: title }])
       head.push(['meta', { name: 'twitter:description', content: description }])
 
-      // Add structured data for paper and article pages
-      const isPaperPage = pageData.relativePath.includes('papers/') && !pageData.relativePath.endsWith('papers/index.md')
-      const isArticlePage = pageData.relativePath.includes('articles/') && !pageData.relativePath.endsWith('articles/index.md')
+      // Structured data: TechArticle for individual paper and article pages
       if (isPaperPage || isArticlePage) {
         const structuredData = {
           '@context': 'https://schema.org',
@@ -116,7 +121,8 @@ export default withMermaid(
           description: description,
           author: {
             '@type': 'Person',
-            name: 'David Daniel'
+            name: 'David Daniel',
+            url: 'https://daviddaniel.tech'
           },
           publisher: {
             '@type': 'Person',
@@ -139,6 +145,61 @@ export default withMermaid(
           JSON.stringify(structuredData)
         ])
       }
+
+      // Structured data: WebPage for index and listing pages
+      if (pageData.relativePath === 'index.md' || pageData.relativePath === 'papers/index.md' || pageData.relativePath === 'articles/index.md') {
+        head.push([
+          'script',
+          { type: 'application/ld+json' },
+          JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'WebPage',
+            name: title,
+            description: description,
+            url: canonicalUrl,
+            author: {
+              '@type': 'Person',
+              name: 'David Daniel',
+              url: 'https://daviddaniel.tech'
+            }
+          })
+        ])
+      }
+
+      // Structured data: BreadcrumbList for navigation
+      const breadcrumbItems = [
+        {
+          '@type': 'ListItem',
+          position: 1,
+          name: 'Home',
+          item: 'https://daviddaniel.tech'
+        },
+        {
+          '@type': 'ListItem',
+          position: 2,
+          name: 'Research',
+          item: `${siteUrl}/`
+        }
+      ]
+
+      if (isContentPage) {
+        breadcrumbItems.push({
+          '@type': 'ListItem',
+          position: 3,
+          name: title,
+          item: canonicalUrl
+        })
+      }
+
+      head.push([
+        'script',
+        { type: 'application/ld+json' },
+        JSON.stringify({
+          '@context': 'https://schema.org',
+          '@type': 'BreadcrumbList',
+          itemListElement: breadcrumbItems
+        })
+      ])
 
       pageData.frontmatter.head = head
     },

--- a/docs/articles/autonomous-agents-loop/index.md
+++ b/docs/articles/autonomous-agents-loop/index.md
@@ -1,6 +1,7 @@
 ---
 title: "The Autonomous Agents Loop: Why AI Agents Produce Better Output When You Stop Interrupting Them"
 description: Why autonomous AI execution loops outperform interactive assistance, and how enterprises can build the execution environment, context management, and multi-agent infrastructure to capture those gains.
+author: David Daniel
 date: 2026-02-13
 ---
 

--- a/docs/articles/index.md
+++ b/docs/articles/index.md
@@ -1,7 +1,8 @@
 ---
 title: Articles
-date: 2026-02-13
 description: Practitioner-focused articles on scaling agentic development, specification infrastructure, and autonomous execution patterns for enterprise teams.
+author: David Daniel
+date: 2026-02-13
 ---
 
 # Articles

--- a/docs/articles/specification-layer/index.md
+++ b/docs/articles/specification-layer/index.md
@@ -1,6 +1,7 @@
 ---
 title: "The Specification Layer: Why Enterprises Can't Scale AI Development Without It"
 description: Why explicit, machine-readable specifications are the missing infrastructure for scaling agentic development across enterprise teams. Covers AGENTS.md, CLAUDE.md, SDD frameworks, and the four-tier specification architecture.
+author: David Daniel
 date: 2026-02-13
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,9 @@
 ---
 layout: home
 title: Spec-Driven Development & Agentic AI Tools Research
-date: 2026-02-13
 description: In-depth technical analysis on software development frameworks, AI-powered development tools, and engineering practices for architects and engineering professionals.
+author: David Daniel
+date: 2026-02-13
 
 hero:
   name: Research Papers & Articles

--- a/docs/papers/agentic-tools/comparative-analysis.md
+++ b/docs/papers/agentic-tools/comparative-analysis.md
@@ -1,7 +1,8 @@
 ---
 title: Agentic Tools Comparative Analysis
-date: 2026-01-07
 description: Side-by-side architectural comparison of Claude Code, Goose, Cursor, and GitHub Copilot. Includes failure modes, operational risks, and governance implications.
+author: David Daniel
+date: 2026-01-07
 ---
 
 # Comparative Analysis

--- a/docs/papers/agentic-tools/index.md
+++ b/docs/papers/agentic-tools/index.md
@@ -1,7 +1,8 @@
 ---
 title: Agentic Development Tools and Execution Architectures
-date: 2026-01-07
 description: Architectural comparison of Claude Code, Goose, Cursor, and GitHub Copilot. Analysis of execution models, autonomy boundaries, and context management for enterprise adoption.
+author: David Daniel
+date: 2026-01-07
 ---
 
 # Agentic Development Tools and Execution Architectures

--- a/docs/papers/agentic-tools/references.md
+++ b/docs/papers/agentic-tools/references.md
@@ -1,7 +1,8 @@
 ---
 title: Agentic Tools References and Resources
-date: 2026-01-07
 description: Conclusion and official documentation links for Claude Code, Goose, Cursor, and GitHub Copilot. Resources for further exploration of agentic development tools.
+author: David Daniel
+date: 2026-01-07
 ---
 
 # References and Resources

--- a/docs/papers/agentic-tools/references.md
+++ b/docs/papers/agentic-tools/references.md
@@ -135,7 +135,7 @@ If citing this research in academic or professional work, please use:
 
 ```
 Daniel, David (2026). Agentic Development Tools and Execution Architectures.
-Retrieved from https://davidedaniel.github.io/research/papers/agentic-tools/
+Retrieved from https://daviddaniel.tech/research/papers/agentic-tools/
 ```
 
 ---

--- a/docs/papers/agentic-tools/terminology-taxonomy.md
+++ b/docs/papers/agentic-tools/terminology-taxonomy.md
@@ -1,7 +1,8 @@
 ---
 title: Agentic Tools Terminology and Taxonomy
-date: 2026-01-07
 description: Key definitions and architectural taxonomy for categorizing agentic development tools. Distinguishes assistive AI, IDE-native agents, platform-embedded agents, and multi-context systems.
+author: David Daniel
+date: 2026-01-07
 ---
 
 # Terminology and Taxonomy

--- a/docs/papers/agentic-tools/tool-analysis.md
+++ b/docs/papers/agentic-tools/tool-analysis.md
@@ -1,7 +1,8 @@
 ---
 title: Agentic Development Tool Analysis
-date: 2026-01-07
 description: Detailed architectural analysis of Claude Code, Goose, Cursor, and GitHub Copilot. Examines execution models, context management, and integration patterns.
+author: David Daniel
+date: 2026-01-07
 ---
 
 # Tool Analysis

--- a/docs/papers/autonomous-agents/adjacent-domains.md
+++ b/docs/papers/autonomous-agents/adjacent-domains.md
@@ -1,6 +1,7 @@
 ---
 title: Adjacent Domains and Mechanisms
 description: Evidence for autonomous iteration advantages from game AI, autonomous driving, and medical screening, plus analysis of interruption costs and scaling laws.
+author: David Daniel
 date: 2026-02-01
 ---
 

--- a/docs/papers/autonomous-agents/benchmarks.md
+++ b/docs/papers/autonomous-agents/benchmarks.md
@@ -1,6 +1,7 @@
 ---
 title: SWE-bench and Multi-Agent Execution
 description: Analysis of SWE-bench benchmark results showing how agentic scaffolding produces order-of-magnitude improvements, plus the Anthropic C compiler multi-agent experiment.
+author: David Daniel
 date: 2026-02-01
 ---
 

--- a/docs/papers/autonomous-agents/conclusions.md
+++ b/docs/papers/autonomous-agents/conclusions.md
@@ -1,6 +1,7 @@
 ---
 title: Conclusions and References
 description: Where autonomous loops outperform interactive assistance and where they fall short, the case for investing in infrastructure now, and complete reference list.
+author: David Daniel
 date: 2026-02-01
 ---
 

--- a/docs/papers/autonomous-agents/index.md
+++ b/docs/papers/autonomous-agents/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Autonomous AI Agents: Execution Loops vs Interactive Assistance"
 description: Evidence synthesis comparing autonomous AI agent execution loops against interactive human-in-the-loop assistance. Covers SWE-bench benchmarks, the METR RCT, industry telemetry, adjacent domain evidence, and mechanisms.
+author: David Daniel
 date: 2026-02-01
 ---
 

--- a/docs/papers/autonomous-agents/productivity-evidence.md
+++ b/docs/papers/autonomous-agents/productivity-evidence.md
@@ -1,6 +1,7 @@
 ---
 title: Developer Productivity Evidence
 description: Analysis of the METR RCT, Faros AI telemetry, Stack Overflow survey data, and DORA reports on real-world developer productivity with AI tools.
+author: David Daniel
 date: 2026-02-01
 ---
 

--- a/docs/papers/index.md
+++ b/docs/papers/index.md
@@ -1,7 +1,8 @@
 ---
 title: Research Papers
-date: 2026-01-07
 description: Browse technical research papers on spec-driven development, agentic tools, software architecture, and modern engineering practices.
+author: David Daniel
+date: 2026-01-07
 ---
 
 # Research Papers

--- a/docs/papers/sdd-frameworks/adjacent-technologies.md
+++ b/docs/papers/sdd-frameworks/adjacent-technologies.md
@@ -1,7 +1,8 @@
 ---
 title: Adjacent Technologies and Ecosystem Integration
-date: 2026-01-07
 description: Analysis of BDD frameworks (Cucumber, SpecFlow, Behave) and contract testing ecosystems (Pact, PactFlow) that complement specification-driven development.
+author: David Daniel
+date: 2026-01-07
 ---
 
 # Adjacent Technologies & Ecosystem Integration

--- a/docs/papers/sdd-frameworks/foundational-theory.md
+++ b/docs/papers/sdd-frameworks/foundational-theory.md
@@ -1,7 +1,8 @@
 ---
 title: Foundational Theory - Understanding Spec-Driven Development
-date: 2026-01-07
 description: Deep dive into TDD, BDD, Test Pyramid, and Consumer-Driven Contract testing. Theoretical foundations underlying modern specification-driven development frameworks.
+author: David Daniel
+date: 2026-01-07
 ---
 
 # Foundational Theory: Understanding Spec-Driven Development

--- a/docs/papers/sdd-frameworks/frameworks-comparison.md
+++ b/docs/papers/sdd-frameworks/frameworks-comparison.md
@@ -1,7 +1,8 @@
 ---
 title: Enterprise-Grade SDD Framework Comparison
-date: 2026-01-07
 description: Detailed comparison of BMAD, SpecKit, and OpenSpec including architectural approaches, workflow stages, enterprise adoption patterns, and decision matrices.
+author: David Daniel
+date: 2026-01-07
 ---
 
 # Enterprise-Grade Framework Comparison

--- a/docs/papers/sdd-frameworks/getting-started.md
+++ b/docs/papers/sdd-frameworks/getting-started.md
@@ -1,7 +1,8 @@
 ---
 title: Getting Started with Spec-Driven Development
-date: 2026-01-07
 description: Practical guide for implementing BMAD, SpecKit, and OpenSpec frameworks. Includes quick-start instructions, core concepts, and framework selection guidance.
+author: David Daniel
+date: 2026-01-07
 ---
 
 # Getting Started with Spec-Driven Development

--- a/docs/papers/sdd-frameworks/index.md
+++ b/docs/papers/sdd-frameworks/index.md
@@ -1,7 +1,8 @@
 ---
 title: Spec-Driven Development Framework Patterns
-date: 2026-01-07
 description: Comprehensive analysis of BMAD, SpecKit, and OpenSpec frameworks for specification-driven development. Includes framework comparison, foundational theory, and enterprise adoption guidance.
+author: David Daniel
+date: 2026-01-07
 ---
 
 # Spec-Driven Development Framework Patterns


### PR DESCRIPTION
## Summary

This PR improves SEO and structured data implementation across the research site by adding dynamic Open Graph types, comprehensive JSON-LD structured data (TechArticle, WebPage, BreadcrumbList), and standardizing author metadata in all page frontmatter.

## Key Changes

**VitePress Configuration (`docs/.vitepress/config.js`)**
- Added `titleTemplate: ':title | David Daniel Research'` for consistent branding in browser tabs and social shares
- Changed hardcoded `og:site_name` from variable to literal `'David Daniel Research'`
- Removed static `og:type: 'website'` to enable dynamic per-page values
- Implemented dynamic `og:type` logic: `'article'` for papers/articles, `'website'` for index/listing pages
- Added JSON-LD structured data generation in `transformPageData` hook:
  - **TechArticle** schema for individual paper and article pages (with author URL)
  - **WebPage** schema for index and listing pages
  - **BreadcrumbList** schema for all pages (Home → Research → current page)
- Added author URL (`https://daviddaniel.tech`) to structured data Person objects

**Frontmatter Standardization**
- Added `author: David Daniel` field to all markdown files (required for structured data)
- Reordered frontmatter fields for consistency: `title`, `description`, `author`, `date`
- Updated 15+ markdown files across papers and articles sections

**Documentation Updates (`CLAUDE.md`)**
- Added "Content Policy (CRITICAL)" section emphasizing markdown body content is frozen
- Expanded "SEO Requirements" with critical invariants and build verification steps
- Updated frontmatter requirements to include `author` field
- Enhanced SEO checklist with new required fields and verification steps
- Added structured data documentation for TechArticle, WebPage, and BreadcrumbList schemas

**Setup Instructions (`SETUP_INSTRUCTIONS.md`)**
- Updated all references from `davidedaniel.github.io/research/` to `daviddaniel.tech/research/` (custom domain)

## Implementation Details

- Dynamic page type detection uses `pageData.relativePath` to identify papers/articles vs index pages
- Structured data uses `canonicalUrl` to ensure correct URLs in JSON-LD blocks
- BreadcrumbList always includes Home and Research, with current page added only for content pages
- All changes maintain backward compatibility with existing page content

https://claude.ai/code/session_01TevaFessFGv5QksdaByrP2