### PR TITLE
Add Always-On Enterprise Agents paper and Parts 3–4 companion articles

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -265,6 +265,21 @@ export default withMermaid(
               { text: 'Conclusions & References', link: '/papers/autonomous-agents/conclusions' }
             ]
           }
+        ],
+        '/papers/always-on-agents/': [
+          {
+            text: 'Always-On Enterprise Agents',
+            items: [
+              { text: 'Overview', link: '/papers/always-on-agents/' },
+              { text: 'Enterprise Agent Archetypes', link: '/papers/always-on-agents/#enterprise-agent-archetypes' },
+              { text: 'Evidence from Current Systems', link: '/papers/always-on-agents/#evidence-from-current-systems' },
+              { text: 'The Identity Anchor', link: '/papers/always-on-agents/#the-identity-anchor-agents-as-delegated-actors' },
+              { text: 'Reference Architecture', link: '/papers/always-on-agents/#reference-architecture' },
+              { text: 'Productivity Hypothesis', link: '/papers/always-on-agents/#the-productivity-hypothesis' },
+              { text: 'Comparison Table', link: '/papers/always-on-agents/#comparison-table' },
+              { text: 'Conclusion & References', link: '/papers/always-on-agents/#conclusion' }
+            ]
+          }
         ]
       },
 

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -52,12 +52,8 @@ export default withMermaid(
     // Clean URLs without .html extension
     cleanUrls: true,
 
-    // Ignore dead links to external anchor targets that may not resolve at build time.
-    // Part 4 of the "Scaling Agentic Development" article series is in preparation; its
-    // link is referenced from Part 3 and should be tolerated until Part 4 lands.
-    ignoreDeadLinks: [
-      /^\/articles\/copilot-to-principal(\/|\/index)?$/
-    ],
+    // Ignore dead links to external anchor targets that may not resolve at build time
+    ignoreDeadLinks: [],
 
     // Global head configuration
     head: [
@@ -222,7 +218,8 @@ export default withMermaid(
             items: [
               { text: 'The Specification Layer', link: '/articles/specification-layer/' },
               { text: 'The Autonomous Agents Loop', link: '/articles/autonomous-agents-loop/' },
-              { text: 'The Security Debt of Always-On Agents', link: '/articles/security-debt-always-on-agents/' }
+              { text: 'The Security Debt of Always-On Agents', link: '/articles/security-debt-always-on-agents/' },
+              { text: 'From Copilot to Principal', link: '/articles/copilot-to-principal/' }
             ]
           }
         ],
@@ -232,7 +229,8 @@ export default withMermaid(
             items: [
               { text: 'The Specification Layer', link: '/articles/specification-layer/' },
               { text: 'The Autonomous Agents Loop', link: '/articles/autonomous-agents-loop/' },
-              { text: 'The Security Debt of Always-On Agents', link: '/articles/security-debt-always-on-agents/' }
+              { text: 'The Security Debt of Always-On Agents', link: '/articles/security-debt-always-on-agents/' },
+              { text: 'From Copilot to Principal', link: '/articles/copilot-to-principal/' }
             ]
           }
         ],
@@ -242,7 +240,19 @@ export default withMermaid(
             items: [
               { text: 'The Specification Layer', link: '/articles/specification-layer/' },
               { text: 'The Autonomous Agents Loop', link: '/articles/autonomous-agents-loop/' },
-              { text: 'The Security Debt of Always-On Agents', link: '/articles/security-debt-always-on-agents/' }
+              { text: 'The Security Debt of Always-On Agents', link: '/articles/security-debt-always-on-agents/' },
+              { text: 'From Copilot to Principal', link: '/articles/copilot-to-principal/' }
+            ]
+          }
+        ],
+        '/articles/copilot-to-principal/': [
+          {
+            text: 'Scaling Agentic Development',
+            items: [
+              { text: 'The Specification Layer', link: '/articles/specification-layer/' },
+              { text: 'The Autonomous Agents Loop', link: '/articles/autonomous-agents-loop/' },
+              { text: 'The Security Debt of Always-On Agents', link: '/articles/security-debt-always-on-agents/' },
+              { text: 'From Copilot to Principal', link: '/articles/copilot-to-principal/' }
             ]
           }
         ],

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -52,8 +52,12 @@ export default withMermaid(
     // Clean URLs without .html extension
     cleanUrls: true,
 
-    // Ignore dead links to external anchor targets that may not resolve at build time
-    ignoreDeadLinks: [],
+    // Ignore dead links to external anchor targets that may not resolve at build time.
+    // Part 4 of the "Scaling Agentic Development" article series is in preparation; its
+    // link is referenced from Part 3 and should be tolerated until Part 4 lands.
+    ignoreDeadLinks: [
+      /^\/articles\/copilot-to-principal(\/|\/index)?$/
+    ],
 
     // Global head configuration
     head: [
@@ -217,7 +221,8 @@ export default withMermaid(
             text: 'Scaling Agentic Development',
             items: [
               { text: 'The Specification Layer', link: '/articles/specification-layer/' },
-              { text: 'The Autonomous Agents Loop', link: '/articles/autonomous-agents-loop/' }
+              { text: 'The Autonomous Agents Loop', link: '/articles/autonomous-agents-loop/' },
+              { text: 'The Security Debt of Always-On Agents', link: '/articles/security-debt-always-on-agents/' }
             ]
           }
         ],
@@ -226,7 +231,18 @@ export default withMermaid(
             text: 'Scaling Agentic Development',
             items: [
               { text: 'The Specification Layer', link: '/articles/specification-layer/' },
-              { text: 'The Autonomous Agents Loop', link: '/articles/autonomous-agents-loop/' }
+              { text: 'The Autonomous Agents Loop', link: '/articles/autonomous-agents-loop/' },
+              { text: 'The Security Debt of Always-On Agents', link: '/articles/security-debt-always-on-agents/' }
+            ]
+          }
+        ],
+        '/articles/security-debt-always-on-agents/': [
+          {
+            text: 'Scaling Agentic Development',
+            items: [
+              { text: 'The Specification Layer', link: '/articles/specification-layer/' },
+              { text: 'The Autonomous Agents Loop', link: '/articles/autonomous-agents-loop/' },
+              { text: 'The Security Debt of Always-On Agents', link: '/articles/security-debt-always-on-agents/' }
             ]
           }
         ],

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -277,7 +277,8 @@ export default withMermaid(
               { text: 'Reference Architecture', link: '/papers/always-on-agents/#reference-architecture' },
               { text: 'Productivity Hypothesis', link: '/papers/always-on-agents/#the-productivity-hypothesis' },
               { text: 'Comparison Table', link: '/papers/always-on-agents/#comparison-table' },
-              { text: 'Conclusion & References', link: '/papers/always-on-agents/#conclusion' }
+              { text: 'Conclusion & References', link: '/papers/always-on-agents/#conclusion' },
+              { text: 'Citation', link: '/papers/always-on-agents/#citation' }
             ]
           }
         ]

--- a/docs/articles/autonomous-agents-loop/index.md
+++ b/docs/articles/autonomous-agents-loop/index.md
@@ -7,7 +7,7 @@ date: 2026-02-13
 
 # The Autonomous Agents Loop: Why AI Agents Produce Better Output When You Stop Interrupting Them
 
-*Part 2 of 2: Scaling Agentic Development for Enterprise Teams*
+*Part 2 of the "Scaling Agentic Development" series*
 
 **Published:** February 2026 | **Author:** David Daniel
 
@@ -145,7 +145,7 @@ And they'll let their agents run.
 
 ---
 
-*This is Part 2 of a two-part series on scaling agentic development for enterprise teams. Part 1, [The Specification Layer](/articles/specification-layer/), covers why specifications and structured instructions are the missing enterprise scaling strategy.*
+*This is Part 2 of the "Scaling Agentic Development" series on scaling agentic development for enterprise teams. Part 1, [The Specification Layer](/articles/specification-layer/), covers why specifications and structured instructions are the missing enterprise scaling strategy. Part 3, [The Security Debt of Always-On Agents](/articles/security-debt-always-on-agents/), covers the governance boundary persistent agents require once they run against real systems.*
 
 *For the empirical evidence base, see [Autonomous AI Agents: Execution Loops vs Interactive Assistance](/papers/autonomous-agents/). For architectural analysis of the tools discussed here, see [Agentic Development Tools and Execution Architectures](/papers/agentic-tools/). For SDD framework comparisons, see [Spec-Driven Development Framework Patterns](/papers/sdd-frameworks/).*
 
@@ -156,6 +156,7 @@ And they'll let their agents run.
 - [Autonomous AI Agents: Execution Loops vs Interactive Assistance](/papers/autonomous-agents/) — Evidence synthesis on execution loops vs interactive assistance
 - [Agentic Development Tools and Execution Architectures](/papers/agentic-tools/) — Architectural comparison of Claude Code, Goose, Cursor, and GitHub Copilot
 - [The Specification Layer](/articles/specification-layer/) — Part 1: Why enterprises need explicit specifications to scale agentic development
+- [The Security Debt of Always-On Agents](/articles/security-debt-always-on-agents/) — Part 3: Why the enterprise security stack collapses when agents interact with data directly
 
 ---
 

--- a/docs/articles/autonomous-agents-loop/index.md
+++ b/docs/articles/autonomous-agents-loop/index.md
@@ -145,7 +145,7 @@ And they'll let their agents run.
 
 ---
 
-*This is Part 2 of the "Scaling Agentic Development" series on scaling agentic development for enterprise teams. Part 1, [The Specification Layer](/articles/specification-layer/), covers why specifications and structured instructions are the missing enterprise scaling strategy. Part 3, [The Security Debt of Always-On Agents](/articles/security-debt-always-on-agents/), covers the governance boundary persistent agents require once they run against real systems.*
+*This is Part 2 of the "Scaling Agentic Development" series on scaling agentic development for enterprise teams. Part 1, [The Specification Layer](/articles/specification-layer/), covers why specifications and structured instructions are the missing enterprise scaling strategy. Part 3, [The Security Debt of Always-On Agents](/articles/security-debt-always-on-agents/), covers the governance boundary persistent agents require once they run against real systems. Part 4, [From Copilot to Principal](/articles/copilot-to-principal/), examines how persistent agents reorganize knowledge work and the emerging role of the human as principal rather than producer.*
 
 *For the empirical evidence base, see [Autonomous AI Agents: Execution Loops vs Interactive Assistance](/papers/autonomous-agents/). For architectural analysis of the tools discussed here, see [Agentic Development Tools and Execution Architectures](/papers/agentic-tools/). For SDD framework comparisons, see [Spec-Driven Development Framework Patterns](/papers/sdd-frameworks/).*
 
@@ -157,6 +157,7 @@ And they'll let their agents run.
 - [Agentic Development Tools and Execution Architectures](/papers/agentic-tools/) — Architectural comparison of Claude Code, Goose, Cursor, and GitHub Copilot
 - [The Specification Layer](/articles/specification-layer/) — Part 1: Why enterprises need explicit specifications to scale agentic development
 - [The Security Debt of Always-On Agents](/articles/security-debt-always-on-agents/) — Part 3: Why the enterprise security stack collapses when agents interact with data directly
+- [From Copilot to Principal](/articles/copilot-to-principal/) — Part 4: How persistent always-on agents reorganize knowledge work
 
 ---
 

--- a/docs/articles/copilot-to-principal/index.md
+++ b/docs/articles/copilot-to-principal/index.md
@@ -1,0 +1,122 @@
+---
+title: "From Copilot to Principal: How Always-On Agents Reorganize Knowledge Work"
+description: Why persistent always-on AI agents do not shrink the human role, they invert it, and why most organizations are not structurally ready for the principal role this creates.
+author: David Daniel
+date: 2026-04-13
+---
+
+# From Copilot to Principal: How Always-On Agents Reorganize Knowledge Work
+
+*Part 4 of the "Scaling Agentic Development" series*
+
+**Published:** April 2026 | **Author:** David Daniel
+
+---
+
+In a Cisco blog post, DJ Sampath describes running OpenClaw on a DGX Spark in his home office. As Sampath writes, it manages his family's schedules, pulls up school lunch menus, tracks his kids' activities, syncs email and calendar through MCP servers, and serves as what he calls his "deepest thinking partner." When he starts his day, as he describes it, his job is not to drive the keyboard. His job is to review what the agent produced, accept what is usable, redirect what is not, and assign the next batch of goals.
+
+That anecdote matters less as a product story than as a work pattern. The important shift is not better autocomplete. It is that execution has moved elsewhere, and the human's role has changed in response.
+
+This is the transition most organizations are still misreading. They are treating agents as a tooling upgrade layered on top of the copilot model. In practice, persistent agents change the role of the human sitting next to the system. The human is no longer primarily the one doing the work. The human becomes the one who defines goals, sets constraints, reviews outcomes, and decides what runs next.
+
+Agents in this model are not interactive tools. They are delegated execution contexts.
+
+## The Overnight Test
+
+There is a simple diagnostic for whether a team has actually made this transition.
+
+If you shut your laptop at seven in the evening, does any useful knowledge work happen between then and nine the next morning that you did not explicitly schedule a human to do?
+
+If the answer is no, you are still operating the copilot model, even if you have bought agent licenses. If the answer is yes, the system has changed, and the questions that follow are not about tooling. They are about ownership.
+
+Who reviewed the output? Who approved the authority it used? Who defined the constraints under which it ran? Who is accountable if the overnight run produces something wrong, expensive, or embarrassing?
+
+Those are not cosmetic questions. They are the structure of the new human role, and most organizations do not have answers for them yet.
+
+## Delegation, Not Assistance
+
+The copilot model has a specific shape. A developer prompts, the model responds, the developer corrects, and the loop continues. Each cycle is synchronous, short-lived, and initiated by the human. The human remains inside the loop as both orchestrator and reviewer.
+
+That interaction pattern has now been studied enough to identify its limits. The METR randomized controlled trial found that experienced open-source developers using AI tools took 19 percent longer to complete tasks compared to working without AI, despite forecasting a 24 percent speedup beforehand and estimating afterward that AI had reduced their completion time by 20 percent (Becker et al., arXiv:2507.09089, July 2025). The study authors note that results may not generalize to settings with autonomous loops, greenfield projects, or less experienced developers. But the finding that applies here is specific: the copilot interaction pattern (short, synchronous, human-in-the-loop) pushes coordination cost back onto the human. The generation gets cheaper, but the supervision gets more expensive.
+
+The persistent agent model changes the architecture. Instead of a transient chat session, the system has a process. Instead of a context window that disappears at the end of an exchange, it has durable memory and recoverable state. Instead of waiting for the next prompt, it can continue execution while the human is absent.
+
+Once work can be delegated into a process that persists across time, the economic question changes. It is no longer "how fast can the model answer my question?" It becomes "how much useful work can continue when I am not there?"
+
+## The Principal Role
+
+Patrick Debois described one of the defining patterns of AI-native development as "producer to manager," which is a useful frame because it captures the shift from direct production to review and delegation.
+
+But "manager" is slightly off. Manager suggests supervision of people. Persistent agents introduce a different kind of relationship. In legal and economic terms, a principal is the party on whose behalf an agent acts. That language now fits the operating model better than the language of management.
+
+A principal does three things: defines the objective, sets the constraints, and reviews the result. That is increasingly what the human does in a persistent agent system.
+
+The point is not that execution disappears from the human's day. The point is that execution stops being the main bottleneck. The human's scarce resource becomes judgment: the ability to define what should be done, recognize when the result is wrong, and decide what to do about it. That sounds more strategic, and it is. It is also more demanding. A principal can hide less easily than a producer. If the role is to decide what should run and whether what came back is acceptable, then ambiguity in accountability becomes harder to tolerate.
+
+This is why the transition is not just technical. It is organizational and psychological. Many teams are happy to experiment with AI assistance. Fewer are prepared to redesign work around delegated execution and explicit review ownership.
+
+## The Organizational Math
+
+The most important productivity shift from persistent agents is not speed. It is coverage.
+
+Interactive systems are bounded by human working hours. Persistent systems are bounded by system constraints (compute, API rate limits, policy gates) rather than by whether a human is actively watching. That leads to a different productivity equation: time multiplied by coverage, not speed alone.
+
+A developer who dispatches three coding agents at end-of-day (one running tests on a refactored module, one collecting benchmark data, one triaging lint failures) is not magically working faster. The workflow is completing faster because idle hours have been converted into execution hours. The developer's own speed has not changed. The cycle time has compressed. Whether this compression translates to net productivity gains depends on the quality of the specifications, the reliability of the execution loops, and the review burden the output creates, variables that are not yet well-measured at enterprise scale.
+
+The *Cybernetic Teammate* study offers a suggestive parallel from a different domain. In a pre-registered field experiment with 776 professionals at Procter & Gamble working on real product innovation challenges, the researchers found that individuals using AI matched the performance of teams without AI, suggesting that AI can effectively replicate certain benefits of human collaboration (Dell'Acqua et al., HBS Working Paper 25-043, 2025). The study was conducted with consumer goods professionals on product development tasks, so its applicability to software engineering specifically is suggestive rather than direct. But the result matters because it implies that a significant portion of what teams produce comes from coordination and knowledge-sharing functions that AI can partially substitute. Persistent agents extend that logic across time. In the author's view, they reduce coordination overhead not just within a single task, but across the gaps between tasks: the overnight builds, the weekend test runs, the hours spent waiting for intermediate results before the next step can begin.
+
+## Why Most Enterprises Are Not Ready
+
+The readiness gap is not about whether agents can run. They can. The gap is whether organizations have the role design and governance model to absorb them.
+
+Most enterprises have distributed AI access. They have not redesigned around it. In the author's assessment, that means many organizations lack explicit ownership for agent outputs, formal review bandwidth for asynchronously generated work, clear thresholds for what an agent can approve or trigger on its own, and stable ways to measure whether delegated execution is improving throughput or just producing more artifacts to review. These are structural gaps that follow from the speed of AI adoption outpacing organizational redesign.
+
+This is where the earlier parts of this series become prerequisites rather than background. The principal role depends on having something stable to delegate into. Without specification-driven workflows ([Part 1](/articles/specification-layer/)) that define what an agent should execute end-to-end, and without reliable autonomous execution loops ([Part 2](/articles/autonomous-agents-loop/)) that can run without constant intervention, there is nothing stable to delegate into, and the principal model collapses back into assisted execution: the human doing the work with occasional AI suggestions.
+
+Organizations do not fail at this transition because they lack AI capability. They fail because they lack the system where delegation is safe, review is structured, and accountability is explicit.
+
+## The New Bottleneck Is Judgment Bandwidth
+
+The old bottleneck in software and knowledge work was execution capacity. How fast could a person write, analyze, draft, test, or triage?
+
+Persistent agents move part of that bottleneck into the system. The new constraint becomes the human's ability to issue good objectives, review outputs coherently, and maintain standards across a portfolio of delegated work. That is judgment bandwidth, and it is a fundamentally different bottleneck than execution speed.
+
+This is why the principal role matters so much. A principal with weak judgment and broad delegation authority can do more damage than a developer with no AI tools at all. A principal with strong judgment can multiply the output of several agent loops operating in parallel. The question for organizations is not whether this role will emerge; it already is. The question is whether they will recognize it early enough to design for it, or whether they will discover it after the damage from unstructured delegation has already accumulated.
+
+## The Harness Matters More Than the License
+
+There is a temptation to think this transition is mostly about buying the right vendor product. It is not.
+
+The practical requirement is a harness: the execution environment, permission model, memory model, review path, and audit trail that determines how delegated work actually happens. The model matters. The harness matters more. The companion research paper, [Always-On Enterprise Agents](/papers/always-on-agents/), describes the reference architecture for this harness in detail, specifically how identity-bound sessions, tool gateways, and policy engines compose into a governed execution environment. This is where, in the author's analysis, the distinction between consumer-grade agent enthusiasm and enterprise-grade operating models becomes real.
+
+A company does not become ready for persistent agents because employees can install them. It becomes ready when delegated execution happens inside a governed system with clear ownership and bounded authority. That is a bigger shift than "roll out an AI tool." It is closer to redesigning how work enters, moves through, and exits the organization.
+
+## The Principal Era
+
+The phrase "copilot" was useful because it suggested assistance without autonomy. It made the transition feel safe.
+
+That framing is breaking down. Persistent agents do not sit beside the human waiting for the next instruction. They accumulate context, run while the human is gone, interact with tools, and return work products that have to be judged rather than authored.
+
+That does not remove the human. It changes what the human is for.
+
+The next productivity frontier is not better prompting. It is better delegation under governance. The human who can define goals well, constrain execution intelligently, and review outcomes rigorously becomes more valuable, not less. That is the principal role. Most organizations are still buying copilots for a world that is moving toward principals.
+
+---
+
+*This is Part 4 of the "Scaling Agentic Development" series. Part 1: [The Specification Layer](/articles/specification-layer/). Part 2: [The Autonomous Agents Loop](/articles/autonomous-agents-loop/). Part 3: [The Security Debt of Always-On Agents](/articles/security-debt-always-on-agents/).*
+
+*This article is part of an ongoing research project tracking AI tooling, software engineering practices, and cross-functional workflows at [daviddaniel.tech/research](https://daviddaniel.tech/research).*
+
+## Sources
+
+- DJ Sampath, "I Run OpenClaw at Home. That's Exactly Why We Built DefenseClaw," Cisco Blogs, March 23, 2026.
+- Becker et al., "Measuring the Impact of Early-2025 AI on Experienced Open-Source Developer Productivity," arXiv:2507.09089, July 2025. Note: RCT with 16 experienced open-source developers completing 246 tasks; authors caution against generalizing to all developer populations or interaction patterns.
+- Patrick Debois, "4 Patterns of AI Native Development," InfoQ Dev Summit Munich, March 2026.
+- Dell'Acqua et al., "The Cybernetic Teammate," HBS Working Paper 25-043 / NBER Working Paper 33641, 2025. Pre-registered field experiment with 776 professionals at Procter & Gamble on product innovation challenges.
+- Anthropic Managed Agents documentation, 2026.
+
+*For the full reference architecture and identity-bound governance model, see the companion research paper [Always-On Enterprise Agents](/papers/always-on-agents/).*
+
+---
+
+*This article was created with AI assistance. Sources include: DJ Sampath's "I Run OpenClaw at Home. That's Exactly Why We Built DefenseClaw" (Cisco Blogs, March 23, 2026), Becker et al.'s METR developer productivity study (arXiv:2507.09089, July 2025), Patrick Debois's "4 Patterns of AI Native Development" (InfoQ Dev Summit Munich, March 2026), Dell'Acqua et al.'s "The Cybernetic Teammate" (HBS Working Paper 25-043 / NBER Working Paper 33641, 2025), and Anthropic Managed Agents documentation (2026). Data as of April 2026.*

--- a/docs/articles/index.md
+++ b/docs/articles/index.md
@@ -41,6 +41,16 @@ Why the enterprise security stack collapses when AI agents interact with data di
 
 ---
 
+### [From Copilot to Principal: How Always-On Agents Reorganize Knowledge Work](/articles/copilot-to-principal/)
+
+Why persistent always-on AI agents do not shrink the human role, they invert it, and why most organizations are not structurally ready for the principal role this creates. Covers the overnight test, judgment bandwidth as the new bottleneck, and why delegation under governance is the next productivity frontier.
+
+**Topics:** Principal-agent model, delegation under governance, coverage over speed, judgment bandwidth, enterprise operating model
+
+[Read →](/articles/copilot-to-principal/)
+
+---
+
 ## About
 
 These articles are companion pieces to the [research papers](/papers/), translating empirical findings into actionable guidance for engineering leaders and practitioners. They are part of an ongoing series on scaling agentic development for enterprise teams.

--- a/docs/articles/index.md
+++ b/docs/articles/index.md
@@ -1,8 +1,8 @@
 ---
 title: Articles
-description: Practitioner-focused articles on scaling agentic development, specification infrastructure, and autonomous execution patterns for enterprise teams.
+description: Practitioner-focused articles on scaling agentic development, specification infrastructure, autonomous execution, and the security debt of always-on agents for enterprise teams.
 author: David Daniel
-date: 2026-02-13
+date: 2026-04-13
 ---
 
 # Articles
@@ -31,12 +31,23 @@ Why autonomous AI execution loops outperform interactive assistance, and how ent
 
 ---
 
+### [The Security Debt of Always-On Agents](/articles/security-debt-always-on-agents/)
+
+Why the enterprise security stack collapses when AI agents interact with data directly, and what a data-first defensive architecture for persistent agents looks like in practice. Covers identity-bound delegation, harness-level governance, and the tool/data enforcement points that bound persistent execution.
+
+**Topics:** Persistent agents, identity-bound delegation, harness governance, tool gateways, data-layer controls, OpenClaw
+
+[Read →](/articles/security-debt-always-on-agents/)
+
+---
+
 ## About
 
-These articles are companion pieces to the [research papers](/papers/), translating empirical findings into actionable guidance for engineering leaders and practitioners. They are part of a two-part series on scaling agentic development for enterprise teams.
+These articles are companion pieces to the [research papers](/papers/), translating empirical findings into actionable guidance for engineering leaders and practitioners. They are part of an ongoing series on scaling agentic development for enterprise teams.
 
 ## Related Research
 
+- [Always-On Enterprise Agents: Persistent Architecture, Delegated Identity, and the Productivity Hypothesis](/papers/always-on-agents/) — reference architecture for persistent, identity-bound agent systems
 - [Autonomous AI Agents: Execution Loops vs Interactive Assistance](/papers/autonomous-agents/) — the empirical evidence base
 - [Agentic Development Tools and Execution Architectures](/papers/agentic-tools/) — architectural analysis of the tools discussed
 - [Spec-Driven Development Framework Patterns](/papers/sdd-frameworks/) — framework comparison and adoption guidance

--- a/docs/articles/security-debt-always-on-agents/index.md
+++ b/docs/articles/security-debt-always-on-agents/index.md
@@ -1,0 +1,128 @@
+---
+title: "The Security Debt of Always-On Agents"
+description: Why the enterprise security stack collapses when AI agents interact with data directly, and what a data-first defensive architecture for persistent agents looks like in practice.
+author: David Daniel
+date: 2026-04-13
+---
+
+# The Security Debt of Always-On Agents
+
+*Part 3 of the "Scaling Agentic Development" series*
+
+**Published:** April 2026 | **Author:** David Daniel
+
+---
+
+Persistent agents introduce a failure mode that does not exist in interactive systems: execution that outlives the intent that initiated it.
+
+The same loop that makes persistent agents economically interesting — autonomous execution across time, durable memory, tool access, reduced need for human supervision — also makes them operationally dangerous. That is not a moral observation. It is an architectural one. The properties that make these systems useful to enterprises also make them useful to attackers, and the security model most enterprises currently operate was not designed for this shape of work.
+
+That is the security debt of always-on agents.
+
+## The Enterprise Stack Was Built for Human-Shaped Work
+
+Traditional enterprise security assumes a human workflow. A person authenticates, enters an application, clicks through a user interface, reads data, makes changes at human speed, and leaves an audit trail shaped by human attention. Security tools were tuned around that physics: sequential behavior, friction, and rate limits imposed by the person at the keyboard.
+
+Persistent agents do not operate that way. They call APIs directly. They ingest data at machine speed. They follow links, parse instructions embedded in content, and execute tool calls without the visible interaction path that front-end monitoring tools were built to observe. From the agent's perspective, a calendar app is an API with events. A document platform is a corpus to search. A messaging platform is an inbound instruction stream. A browser is an automation substrate.
+
+Once that is true, applications effectively collapse into data stores and tool interfaces. A large part of the existing security model risks becoming secondary, because the controls were built to govern the layer the agent is no longer using. If your defenses depend on click paths, application navigation, or front-end usage patterns, they are no longer sitting where the agent actually works. This framing is directionally consistent with data-centric security analyses from vendors such as Varonis — whose Atlas platform launch materials (March 2026) position data-layer controls as the primary enforcement point for agentic workloads — though the degree to which application-layer controls actually degrade under agent workloads has not yet been rigorously measured across enterprise environments.
+
+## Execution Without Presence
+
+There is a second problem layered on top of the first, and it is the one that makes persistent agents categorically different from other automation.
+
+Interactive systems are constrained by human presence. Persistent systems are not. That means an always-on agent can continue operating after priorities have changed, after policies have been updated, after device posture has shifted, or after the original reason for access is no longer valid.
+
+This might sound like ordinary over-permissioning, and it compounds that problem, but it is something more specific. A misconfigured cron job that keeps running after policies change is executing fixed instructions without judgment. A persistent agent is making contextual decisions — choosing which files to read, which tools to invoke, which actions to take — while operating under authority that may no longer reflect the intent of the person who delegated it. The agent is not just repeating. It is deciding. And it is deciding under stale authorization.
+
+That is the point where agent security stops being an application or endpoint problem and becomes a governance problem. The system has to know not only whether the agent *can* act, but whether it should still be allowed to act on behalf of the human who initiated the work.
+
+This is why identity-bound delegation matters — a constraint explored in detail in the companion research paper's [identity anchor analysis](/papers/always-on-agents/#the-identity-anchor-agents-as-delegated-actors). If execution cannot be attributed, scoped, and revoked over time, then persistent agents remain operationally unsafe even when every individual tool call appears legitimate in isolation.
+
+## What the OpenClaw Moment Revealed
+
+No system has made this pattern more visible than OpenClaw.
+
+Its significance is not just adoption. It is that OpenClaw made a persistent agent architecture legible to a broad audience: durable memory, connected communication channels, shell and browser access, extensible skills, and long-running local execution. That visibility came with immediate security consequences. Based on combined findings from vendor security teams and independent researchers, early analyses documented several categories of exposure shortly after widespread adoption: exposed instances and configuration weaknesses (Cisco / DJ Sampath, "I Run OpenClaw at Home. That's Exactly Why We Built DefenseClaw," Cisco Blogs, March 23, 2026), supply-chain risks through malicious skill distributions on ClawHub (reported in Snyk vulnerability disclosures, 2026), and runtime vulnerabilities in the agent execution environment (reported across Cisco, Snyk, and independent ecosystem audits). The exact scale and exploitability of these issues vary across sources and should be interpreted cautiously. Several were identified within the early weeks of widespread deployment, suggesting the attack surface expands quickly once agents are connected to production systems, though the timeline of discovery does not necessarily indicate the timeline of exploitability.
+
+The details of these incidents are still evolving and in some cases rely on vendor or researcher reporting rather than independently verified incident disclosures. The pattern, however, is structural. Any system that combines persistent execution, broad tool access, and user-installable extensions will reproduce the same category of exposure. OpenClaw did not introduce a unique flaw. It made the architectural category visible before most enterprises had any governance model for it.
+
+The point is not to single out OpenClaw. The point is that the security debt becomes payable the moment a persistent agent connects to real systems with real authority, and most organizations encountered that moment before they had designed for it.
+
+## The Real Attack Surface
+
+Prompt injection gets most of the attention because it is easy to describe, but it is only one expression of a larger condition.
+
+The real attack surface emerges from the combination of untrusted input, persistent memory, tool execution capability, and autonomous continuation. Prompt injection is one way to exploit that combination. Supply-chain compromise through malicious skills or tools is another. Credential exposure through the runtime is another. They all exploit the same underlying condition: text becomes action without sufficient boundaries.
+
+A frontier model judging whether content is suspicious may help. A blocklist for known malicious patterns may help. A human approval step for sensitive actions may help. None of those is sufficient by itself, because the system has to assume hostile content will eventually reach the agent and design for bounded impact when it does.
+
+This is why layered defenses matter more than any single protection, and why Anthropic's framing of the control problem across four layers — model, harness, tools, and environment — as articulated in "Building Effective Agents" (2025) and extended in "Trustworthy Agents in Practice" (2026) — is a more realistic model of enterprise risk than "the AI was tricked." In practice, a well-behaved model can still be compromised by a poorly governed harness, an overly broad tool surface, or an execution environment that exposes the wrong credentials. The attack surface is systemic, not localized to any one layer.
+
+While these patterns are consistently reported across vendors and security research, the long-term failure modes of persistent agents have not yet been studied at enterprise scale. The defensive posture described below is informed by current evidence, but should be treated as directional rather than definitive.
+
+## What Defensive Practice Requires
+
+A usable defensive posture for persistent agents is starting to take shape, and it has five characteristics.
+
+**Deterministic filtering before model reasoning.** External content should first pass through cheap, predictable controls that catch known-bad inputs or disallowed patterns before the agent processes them. Model-based inspection can sit behind that first layer to handle ambiguous cases. This is not elegant. It is practical.
+
+**Per-action permissions, not blanket tool authority.** The agent that can read should not automatically be able to send, delete, approve, or execute arbitrarily. Treating action boundaries as a first-class operational concern — not as a user preference — is what separates enterprise-grade agent deployments from consumer-grade experimentation.
+
+**Credential isolation outside the execution environment.** If generated code runs in the same environment where long-lived tokens are accessible, compromise becomes much easier. Credential access has to be structurally separated from agent execution, not just logically separated by prompt instructions.
+
+**Supply-chain scrutiny at the skill and tool layer.** If the agent can extend itself through plugins, skills, MCP servers, or downloaded tools, that layer becomes part of the production attack surface. It needs review, signing, provenance, and runtime policy — not just marketplace convenience.
+
+**Continuous observability.** Always-on agents require always-on auditability. Tool calls, approvals, policy blocks, state transitions, and unusual access patterns need to flow into the enterprise's actual security and observability systems from day one. This is the point where "AI feature" becomes "security-sensitive infrastructure."
+
+## The Harness Is the Security Boundary
+
+The most important lesson enterprises should draw from the current generation of agent deployments is not "avoid open source" and not "buy a more secure agent platform."
+
+It is that the harness is the security-critical layer.
+
+The model is increasingly substitutable. The runtime can often be standardized. The agent behavior can be specialized. But the harness is where the enterprise actually decides what tools exist, what authority an agent has, how long that authority lasts, how memory is scoped, what requires approval, what is logged, what is revocable, and who is accountable.
+
+If the harness encodes the principal-agent contract — and in practice it does — then inheriting someone else's harness means inheriting someone else's threat model. For some organizations that will be acceptable. For many, especially those operating under regulatory or compliance constraints, it will not.
+
+That does not mean writing everything from scratch. It means assembling the execution model from well-understood components inside an enterprise-controlled boundary, with enterprise-controlled permissions, identity, and audit. The point is ownership of the contract, not handcrafted novelty.
+
+## The Data-First Architecture
+
+Once agents operate directly against data and tools rather than through application UIs, the defensive architecture has to shift downward.
+
+The first requirement is classification. If the organization does not know what data exists and what classes of agents should be able to access it, then the rest of the control model risks becoming largely ineffective. The second is least privilege at the data layer. Agents do not need the broad convenience scopes that humans historically accumulated through years of access requests and role changes. Narrow scopes create little friction for a machine and materially reduce blast radius. The third is anomaly detection based on agent role rather than human behavior. A weather agent reading compensation records is suspicious for a different reason than a person downloading too many files. The detection logic has to reflect the delegated purpose of the agent, not just volume anomalies.
+
+This shift connects directly to the reference architecture described in the companion research paper, [Always-On Enterprise Agents](/papers/always-on-agents/), specifically the interaction between the tool gateway, policy engine, and identity-bound session model. The tool gateway mediates all side effects. The policy engine enforces allow/approve/block decisions. The identity-bound session ensures that the agent's authority traces back to a human subject and can be revoked when conditions change. Without those enforcement points, the application-layer security model is defending a boundary the agent has already moved past.
+
+## What Follows
+
+Parts 1 and 2 of this series argued that reliable autonomous execution requires a specification the agent can read and a loop it can run. This article adds the missing third requirement: a boundary it cannot cross.
+
+That boundary cannot rely on prompt discipline. It cannot rely on the application UI. It cannot rely on the hope that an agent will continue to behave as intended after conditions have changed.
+
+It has to be structural: identity-bound delegation, renewable sessions, tool-boundary governance, data-layer controls, and an internally governed harness. For the full architectural treatment of how these controls compose into a reference architecture, see [Always-On Enterprise Agents: Persistent Architecture, Delegated Identity, and the Productivity Hypothesis](/papers/always-on-agents/). The organizations moving carefully on persistent agents are not necessarily laggards. In many cases they are correctly recognizing that the architecture is still maturing.
+
+But the answer is not indefinite delay. The answer is to treat the security debt of always-on agents as an engineering problem with a recognizable shape and to pay that debt at the harness, identity, and data layers before deployment scales.
+
+The debt is payable. It just is not payable by pretending persistent agents are only smarter copilots.
+
+---
+
+*This is Part 3 of the "Scaling Agentic Development" series. Part 1: [The Specification Layer](/articles/specification-layer/). Part 2: [The Autonomous Agents Loop](/articles/autonomous-agents-loop/). Part 4: [From Copilot to Principal](/articles/copilot-to-principal/).*
+
+*This article is part of an ongoing research project tracking AI tooling, software engineering practices, and cross-functional workflows at [daviddaniel.tech/research](https://daviddaniel.tech/research).*
+
+## Sources
+
+- Anthropic, "Building Effective Agents," 2025; "Trustworthy Agents in Practice," 2026.
+- Cisco / DJ Sampath, "I Run OpenClaw at Home. That's Exactly Why We Built DefenseClaw," Cisco Blogs, March 23, 2026.
+- Snyk, OpenClaw and ClawHub vulnerability disclosures, 2026 (supply-chain and runtime vulnerability analyses referenced in aggregate).
+- Independent OpenClaw ecosystem security reporting and audit analyses, 2026.
+- Varonis, Atlas platform launch materials and data-centric security positioning, March 2026.
+
+*For the full reference architecture and identity-bound governance model, see the companion research paper [Always-On Enterprise Agents](/papers/always-on-agents/).*
+
+---
+
+*This article was created with AI assistance using Claude.*

--- a/docs/articles/security-debt-always-on-agents/index.md
+++ b/docs/articles/security-debt-always-on-agents/index.md
@@ -15,7 +15,7 @@ date: 2026-04-13
 
 Persistent agents introduce a failure mode that does not exist in interactive systems: execution that outlives the intent that initiated it.
 
-The same loop that makes persistent agents economically interesting — autonomous execution across time, durable memory, tool access, reduced need for human supervision — also makes them operationally dangerous. That is not a moral observation. It is an architectural one. The properties that make these systems useful to enterprises also make them useful to attackers, and the security model most enterprises currently operate was not designed for this shape of work.
+The same loop that makes persistent agents economically interesting (autonomous execution across time, durable memory, tool access, reduced need for human supervision) also makes them operationally dangerous. That is not a moral observation. It is an architectural one. The properties that make these systems useful to enterprises also make them useful to attackers, and the security model most enterprises currently operate was not designed for this shape of work.
 
 That is the security debt of always-on agents.
 
@@ -25,7 +25,7 @@ Traditional enterprise security assumes a human workflow. A person authenticates
 
 Persistent agents do not operate that way. They call APIs directly. They ingest data at machine speed. They follow links, parse instructions embedded in content, and execute tool calls without the visible interaction path that front-end monitoring tools were built to observe. From the agent's perspective, a calendar app is an API with events. A document platform is a corpus to search. A messaging platform is an inbound instruction stream. A browser is an automation substrate.
 
-Once that is true, applications effectively collapse into data stores and tool interfaces. A large part of the existing security model risks becoming secondary, because the controls were built to govern the layer the agent is no longer using. If your defenses depend on click paths, application navigation, or front-end usage patterns, they are no longer sitting where the agent actually works. This framing is directionally consistent with data-centric security analyses from vendors such as Varonis — whose Atlas platform launch materials (March 2026) position data-layer controls as the primary enforcement point for agentic workloads — though the degree to which application-layer controls actually degrade under agent workloads has not yet been rigorously measured across enterprise environments.
+Once that is true, applications effectively collapse into data stores and tool interfaces. A large part of the existing security model risks becoming secondary, because the controls were built to govern the layer the agent is no longer using. If your defenses depend on click paths, application navigation, or front-end usage patterns, they are no longer sitting where the agent actually works. This framing is directionally consistent with data-centric security analyses from vendors such as Varonis, whose Atlas platform launch materials (March 2026) position data-layer controls as the primary enforcement point for agentic workloads, though the degree to which application-layer controls actually degrade under agent workloads has not yet been rigorously measured across enterprise environments.
 
 ## Execution Without Presence
 
@@ -33,11 +33,11 @@ There is a second problem layered on top of the first, and it is the one that ma
 
 Interactive systems are constrained by human presence. Persistent systems are not. That means an always-on agent can continue operating after priorities have changed, after policies have been updated, after device posture has shifted, or after the original reason for access is no longer valid.
 
-This might sound like ordinary over-permissioning, and it compounds that problem, but it is something more specific. A misconfigured cron job that keeps running after policies change is executing fixed instructions without judgment. A persistent agent is making contextual decisions — choosing which files to read, which tools to invoke, which actions to take — while operating under authority that may no longer reflect the intent of the person who delegated it. The agent is not just repeating. It is deciding. And it is deciding under stale authorization.
+This might sound like ordinary over-permissioning, and it compounds that problem, but it is something more specific. A misconfigured cron job that keeps running after policies change is executing fixed instructions without judgment. A persistent agent is making contextual decisions (choosing which files to read, which tools to invoke, which actions to take) while operating under authority that may no longer reflect the intent of the person who delegated it. The agent is not just repeating. It is deciding. And it is deciding under stale authorization.
 
 That is the point where agent security stops being an application or endpoint problem and becomes a governance problem. The system has to know not only whether the agent *can* act, but whether it should still be allowed to act on behalf of the human who initiated the work.
 
-This is why identity-bound delegation matters — a constraint explored in detail in the companion research paper's [identity anchor analysis](/papers/always-on-agents/#the-identity-anchor-agents-as-delegated-actors). If execution cannot be attributed, scoped, and revoked over time, then persistent agents remain operationally unsafe even when every individual tool call appears legitimate in isolation.
+This is why identity-bound delegation matters, a constraint explored in detail in the companion research paper's [identity anchor analysis](/papers/always-on-agents/#the-identity-anchor-agents-as-delegated-actors). If execution cannot be attributed, scoped, and revoked over time, then persistent agents remain operationally unsafe even when every individual tool call appears legitimate in isolation.
 
 ## What the OpenClaw Moment Revealed
 
@@ -57,7 +57,7 @@ The real attack surface emerges from the combination of untrusted input, persist
 
 A frontier model judging whether content is suspicious may help. A blocklist for known malicious patterns may help. A human approval step for sensitive actions may help. None of those is sufficient by itself, because the system has to assume hostile content will eventually reach the agent and design for bounded impact when it does.
 
-This is why layered defenses matter more than any single protection, and why Anthropic's framing of the control problem across four layers — model, harness, tools, and environment — as articulated in "Building Effective Agents" (2025) and extended in "Trustworthy Agents in Practice" (2026) — is a more realistic model of enterprise risk than "the AI was tricked." In practice, a well-behaved model can still be compromised by a poorly governed harness, an overly broad tool surface, or an execution environment that exposes the wrong credentials. The attack surface is systemic, not localized to any one layer.
+This is why layered defenses matter more than any single protection, and why Anthropic's framing of the control problem across four layers (model, harness, tools, and environment), as articulated in "Building Effective Agents" (2025) and extended in "Trustworthy Agents in Practice" (2026), is a more realistic model of enterprise risk than "the AI was tricked." In practice, a well-behaved model can still be compromised by a poorly governed harness, an overly broad tool surface, or an execution environment that exposes the wrong credentials. The attack surface is systemic, not localized to any one layer.
 
 While these patterns are consistently reported across vendors and security research, the long-term failure modes of persistent agents have not yet been studied at enterprise scale. The defensive posture described below is informed by current evidence, but should be treated as directional rather than definitive.
 
@@ -67,11 +67,11 @@ A usable defensive posture for persistent agents is starting to take shape, and 
 
 **Deterministic filtering before model reasoning.** External content should first pass through cheap, predictable controls that catch known-bad inputs or disallowed patterns before the agent processes them. Model-based inspection can sit behind that first layer to handle ambiguous cases. This is not elegant. It is practical.
 
-**Per-action permissions, not blanket tool authority.** The agent that can read should not automatically be able to send, delete, approve, or execute arbitrarily. Treating action boundaries as a first-class operational concern — not as a user preference — is what separates enterprise-grade agent deployments from consumer-grade experimentation.
+**Per-action permissions, not blanket tool authority.** The agent that can read should not automatically be able to send, delete, approve, or execute arbitrarily. Treating action boundaries as a first-class operational concern, not as a user preference, is what separates enterprise-grade agent deployments from consumer-grade experimentation.
 
 **Credential isolation outside the execution environment.** If generated code runs in the same environment where long-lived tokens are accessible, compromise becomes much easier. Credential access has to be structurally separated from agent execution, not just logically separated by prompt instructions.
 
-**Supply-chain scrutiny at the skill and tool layer.** If the agent can extend itself through plugins, skills, MCP servers, or downloaded tools, that layer becomes part of the production attack surface. It needs review, signing, provenance, and runtime policy — not just marketplace convenience.
+**Supply-chain scrutiny at the skill and tool layer.** If the agent can extend itself through plugins, skills, MCP servers, or downloaded tools, that layer becomes part of the production attack surface. It needs review, signing, provenance, and runtime policy, not just marketplace convenience.
 
 **Continuous observability.** Always-on agents require always-on auditability. Tool calls, approvals, policy blocks, state transitions, and unusual access patterns need to flow into the enterprise's actual security and observability systems from day one. This is the point where "AI feature" becomes "security-sensitive infrastructure."
 
@@ -83,7 +83,7 @@ It is that the harness is the security-critical layer.
 
 The model is increasingly substitutable. The runtime can often be standardized. The agent behavior can be specialized. But the harness is where the enterprise actually decides what tools exist, what authority an agent has, how long that authority lasts, how memory is scoped, what requires approval, what is logged, what is revocable, and who is accountable.
 
-If the harness encodes the principal-agent contract — and in practice it does — then inheriting someone else's harness means inheriting someone else's threat model. For some organizations that will be acceptable. For many, especially those operating under regulatory or compliance constraints, it will not.
+If the harness encodes the principal-agent contract (and in practice it does), then inheriting someone else's harness means inheriting someone else's threat model. For some organizations that will be acceptable. For many, especially those operating under regulatory or compliance constraints, it will not.
 
 That does not mean writing everything from scratch. It means assembling the execution model from well-understood components inside an enterprise-controlled boundary, with enterprise-controlled permissions, identity, and audit. The point is ownership of the contract, not handcrafted novelty.
 
@@ -125,4 +125,4 @@ The debt is payable. It just is not payable by pretending persistent agents are 
 
 ---
 
-*This article was created with AI assistance using Claude.*
+*This article was created with AI assistance. Sources include: Anthropic's "Building Effective Agents" (2025) and "Trustworthy Agents in Practice" (2026), Cisco / DJ Sampath's "I Run OpenClaw at Home. That's Exactly Why We Built DefenseClaw" (Cisco Blogs, March 23, 2026), Snyk OpenClaw and ClawHub vulnerability disclosures (2026), independent OpenClaw ecosystem security reporting and audit analyses (2026), and Varonis Atlas platform launch materials (March 2026). Data as of April 2026.*

--- a/docs/articles/specification-layer/index.md
+++ b/docs/articles/specification-layer/index.md
@@ -7,7 +7,7 @@ date: 2026-02-13
 
 # The Specification Layer: Why Enterprises Can't Scale AI Development Without It
 
-*Part 1 of 2: Scaling Agentic Development for Enterprise Teams*
+*Part 1 of the "Scaling Agentic Development" series*
 
 **Published:** February 2026 | **Author:** David Daniel
 
@@ -123,7 +123,7 @@ The individual developers at the forefront of this shift have already figured th
 
 ---
 
-*Part 2, [The Autonomous Agents Loop](/articles/autonomous-agents-loop/), explores the execution patterns, recursive loops, multi-agent orchestration, and context management, that turn specifications into shipped software.*
+*Part 2, [The Autonomous Agents Loop](/articles/autonomous-agents-loop/), explores the execution patterns, recursive loops, multi-agent orchestration, and context management, that turn specifications into shipped software. Part 3, [The Security Debt of Always-On Agents](/articles/security-debt-always-on-agents/), examines the governance boundary persistent agents require once they run against real systems.*
 
 *For the empirical evidence base supporting autonomous execution loops, see [Autonomous AI Agents: Execution Loops vs Interactive Assistance](/papers/autonomous-agents/).*
 
@@ -134,6 +134,7 @@ The individual developers at the forefront of this shift have already figured th
 - [Spec-Driven Development Framework Patterns](/papers/sdd-frameworks/) — Comprehensive comparison of BMAD, SpecKit, and OpenSpec
 - [Agentic Development Tools and Execution Architectures](/papers/agentic-tools/) — Architectural comparison of Claude Code, Goose, Cursor, and GitHub Copilot
 - [The Autonomous Agents Loop](/articles/autonomous-agents-loop/) — Part 2: Why AI agents produce better output when they run autonomously
+- [The Security Debt of Always-On Agents](/articles/security-debt-always-on-agents/) — Part 3: Why the enterprise security stack collapses when agents interact with data directly
 
 ---
 

--- a/docs/articles/specification-layer/index.md
+++ b/docs/articles/specification-layer/index.md
@@ -123,7 +123,7 @@ The individual developers at the forefront of this shift have already figured th
 
 ---
 
-*Part 2, [The Autonomous Agents Loop](/articles/autonomous-agents-loop/), explores the execution patterns, recursive loops, multi-agent orchestration, and context management, that turn specifications into shipped software. Part 3, [The Security Debt of Always-On Agents](/articles/security-debt-always-on-agents/), examines the governance boundary persistent agents require once they run against real systems.*
+*Part 2, [The Autonomous Agents Loop](/articles/autonomous-agents-loop/), explores the execution patterns, recursive loops, multi-agent orchestration, and context management, that turn specifications into shipped software. Part 3, [The Security Debt of Always-On Agents](/articles/security-debt-always-on-agents/), examines the governance boundary persistent agents require once they run against real systems. Part 4, [From Copilot to Principal](/articles/copilot-to-principal/), examines how persistent agents reorganize knowledge work and the emerging role of the human as principal rather than producer.*
 
 *For the empirical evidence base supporting autonomous execution loops, see [Autonomous AI Agents: Execution Loops vs Interactive Assistance](/papers/autonomous-agents/).*
 
@@ -135,6 +135,7 @@ The individual developers at the forefront of this shift have already figured th
 - [Agentic Development Tools and Execution Architectures](/papers/agentic-tools/) — Architectural comparison of Claude Code, Goose, Cursor, and GitHub Copilot
 - [The Autonomous Agents Loop](/articles/autonomous-agents-loop/) — Part 2: Why AI agents produce better output when they run autonomously
 - [The Security Debt of Always-On Agents](/articles/security-debt-always-on-agents/) — Part 3: Why the enterprise security stack collapses when agents interact with data directly
+- [From Copilot to Principal](/articles/copilot-to-principal/) — Part 4: How persistent always-on agents reorganize knowledge work
 
 ---
 

--- a/docs/papers/always-on-agents/index.md
+++ b/docs/papers/always-on-agents/index.md
@@ -1,0 +1,370 @@
+---
+title: "Always-On Enterprise Agents: Persistent Architecture, Delegated Identity, and the Productivity Hypothesis"
+description: A research taxonomy of persistent agent patterns for enterprise deployments, grounded in primary vendor documentation. Covers session-anchored architecture, identity-bound governance, and the cycle-time productivity hypothesis.
+author: David Daniel
+date: 2026-04-13
+---
+
+# Always-On Enterprise Agents: Persistent Architecture, Delegated Identity, and the Productivity Hypothesis
+
+*Part 3 of Scaling Agentic Development for Enterprise Teams*
+
+**Published:** April 2026 | **Author:** David Daniel
+
+**Target Audience:** Software architects, platform engineers, and enterprise decision-makers evaluating persistent AI agent systems
+
+---
+
+## Executive Summary
+
+Enterprise agent systems are converging on a long-running shape: durable state outside a single model context window, asynchronous continuation across multiple request/response cycles, and enforceable boundaries where text becomes action. Multiple independent vendor ecosystems now describe long-horizon agents as a first-class deployment target rather than an edge case.
+
+This convergence introduces a structural constraint. This paper argues that enterprise productivity gains from AI are most likely to emerge when work is delegated to long-running agents operating asynchronously under identity-bound governance — though this hypothesis has not yet been validated at enterprise scale. Without mechanisms to bind autonomous execution to human intent over time, persistent agents remain confined to interactive use — bounded by human working hours and direct supervision.
+
+The constraint required is not improved model reasoning but bounded execution. Identity-bound delegation provides this by ensuring that all agent actions remain attributable, scoped, and revocable. This paper provides a deployment-oriented taxonomy of persistent agent architectural patterns, a reference architecture that anchors agents to identity-scoped sessions with tool-boundary governance, and a productivity hypothesis grounded in cycle-time reduction rather than task-speed improvement.
+
+The analysis draws on primary documentation from OpenClaw, NVIDIA NemoClaw, Anthropic Managed Agents, and Databricks, alongside identity standards (OAuth 2.0 Token Exchange, CAEP) and empirical productivity research.
+
+## Introduction
+
+The first two parts of this series established a formula for enterprise AI scaling: specification quality × loop autonomy × context management = reliable output at scale. Part 1 argued that machine-readable specifications are the missing foundation for agentic scaling. Part 2 argued that longer autonomous execution with multi-agent context management outperforms interactive assistance. This paper extends both arguments into persistent territory: what happens when autonomous execution persists across sessions, hours, and organizational boundaries.
+
+Persistent agents represent a shift in the shape of enterprise automation. Instead of request/response interaction constrained to a chat session, persistent agents retain durable context and produce durable work products across time: plans, tickets, diffs, runbooks, approvals, and tool-executed side effects. Anthropic's Claude Managed Agents is explicitly positioned as "best for long-running tasks and asynchronous work," and its engineering documentation formalizes long-running operation as a durable session log plus a harness that can resume after failure and a sandboxed execution layer that can be replaced without losing the session. Databricks is productizing stateful and long-running agent operation in a governed data platform: Agent Bricks explicitly supports scheduling agents on recurring workflows, capturing tool calls and invocations, and giving agents persistent memory via Lakebase. OpenClaw provides an inspectable open-source example of always-on operation with explicit session lifecycle policies and file-backed memory persistence.
+
+Agents in this context are not interactive tools. They are delegated execution contexts.
+
+This shift introduces a structural constraint. As execution persists beyond a single interaction, actions can outlive the intent that initiated them. This creates a new class of failure mode: systems that continue operating correctly according to their instructions, but incorrectly relative to current human intent. A coding agent that continues refactoring a module after priorities shifted overnight. A triage agent that keeps applying a policy that was updated during the previous business day. A review agent that approves changes using criteria that were superseded by a new compliance requirement.
+
+The central question for enterprise adoption is therefore not only how agents execute, but how their execution remains attributable, scoped, and revocable over time. The enterprise question is whether always-on agent behavior will arrive inside the existing governance perimeter — identity, device posture, audit, approvals — or outside it, through ad hoc tokens, unmanaged chat surfaces, and weak attribution.
+
+Persistent agents are not constrained by execution capability. They are constrained by the ability to bind that execution to human intent over time.
+
+This paper provides three contributions. First, a deployment-oriented taxonomy of persistent agent archetypes grounded in current vendor implementations. Second, a reference architecture that introduces identity anchoring and tool-boundary governance as first-class architectural components alongside persistence and execution. Third, a productivity hypothesis that frames always-on agent value as cycle-time reduction through temporal decoupling, with appropriate empirical constraints.
+
+## Enterprise Agent Archetypes
+
+Persistent agent systems can be understood as a transition across three modes: interactive assistance, where execution is human-driven within a single exchange; delegated execution, where agent-driven tasks operate within a bounded session; and continuous execution, where long-running agents operate across sessions independently of human presence. This paper focuses on the third mode, where the architectural requirements diverge most sharply from conventional tooling.
+
+These archetypes should not be interpreted as variations of a single agent system. They represent a portfolio of delegated execution contexts, each operating with distinct responsibilities, authority boundaries, and lifecycle characteristics. In practice, enterprise deployments are composed of multiple specialized agents operating concurrently, rather than a single general-purpose agent.
+
+### Review agents
+
+Review agents focus on evaluating artifacts produced by humans or other agents: code diffs, pull requests, design docs, compliance checklists, incident postmortems, and vendor contracts. Review behavior appears as an explicit control surface in multiple ecosystems. Databricks' Review App enables subject matter experts to review interactions and feed monitoring and evaluation loops. OpenClaw's optional "dreaming" consolidation writes output into `DREAMS.md` for human inspection. NemoClaw requires operator approval for new network destinations during runtime. Anthropic frames per-action permissions and approval tiers as the control mechanism for trustworthy agents — always allow, needs approval, or block — which provides a natural review-agent policy substrate.
+
+Review agents are distinguished by their read-heavy authority profile and their role as quality gates within larger workflows. Their persistence requirement is primarily context continuity: retaining knowledge of what was previously reviewed, what standards apply, and what exceptions have been granted.
+
+### Coding agents
+
+Coding agents perform incremental changes in version-controlled repositories, with tight tool boundaries and a loop of edit, build/test, observe, and iterate. Anthropic's tool combinations documentation defines the canonical coding loop as `text_editor` + `bash`, and its long-running harness research describes an initializer session plus repeated coding sessions that make incremental progress while leaving structured artifacts — progress logs, commit history — for the next session.
+
+Coding agents are distinguished by their write-heavy but version-controlled authority profile. The version control system provides a natural audit trail and rollback mechanism, making this archetype one of the safest for extended autonomous operation.
+
+### Continuation agents
+
+Continuation agents are designed to outlive a single API timeout or work-hour window. This archetype is directly supported by Databricks' long-running task continuation design, which uses `task_continue_request` and `task_continue_response` loops to break long tasks across multiple request/response cycles. Anthropic's Managed Agents are similarly positioned for asynchronous long-running work in managed infrastructure. OpenClaw's background task ledger provides a complementary open-source model for detached work tracking across cron runs and subagent spawns.
+
+Continuation agents are distinguished by their temporal persistence requirement: they must survive interruptions, timeouts, and session boundaries while maintaining coherent progress toward a goal.
+
+### Governed integration agents
+
+Governed integration agents are specialized to operate against enterprise data and systems — databases, ticketing, CI/CD, CRM — with explicit tool governance. Databricks emphasizes unified governance over agents, tools, and MCP servers with end-to-end permissions, positioning MCP as a single governed protocol for connecting tools and data with centrally managed credentials and audit trails. NemoClaw demonstrates a strict variant: even with tool capability, network egress must be explicitly allowed and can be restricted by executable identity and method/path rules.
+
+Governed integration agents are distinguished by their deep coupling with enterprise systems and the corresponding requirement for fine-grained authorization at every tool boundary.
+
+### Archetype interactions
+
+These archetypes are not isolated. A realistic enterprise deployment might involve a continuation agent that dispatches coding agents for implementation work, with review agents evaluating the output before governed integration agents push changes to production systems. The "always-on" capability is not one agent doing everything, but an ecosystem of specialized supervised agents that interact through durable artifacts — tasks, repos, tickets — and explicit approval gates.
+
+Architectures that support asynchronous continuation and identity-bound delegation make it feasible for a single human to supervise multiple concurrent agent tasks, each progressing independently between review cycles.
+
+## Evidence from Current Systems
+
+The following analysis draws on primary vendor documentation to map how current systems implement persistent agent patterns. Each subsection corresponds to architectural decisions that are citable and verifiable.
+
+### OpenClaw: sessions, background tasks, and scheduled persistence
+
+OpenClaw documents a session routing model where inbound messages are routed to sessions based on origin — direct messages, group chats, rooms/channels, cron jobs, and webhooks. The same documentation defines explicit session lifecycle policies (daily reset by default, optional idle reset, manual reset) and describes session state as gateway-owned and stored with transcripts on disk. This makes session boundaries configurable and explicit rather than implicit in a UI.
+
+OpenClaw also defines background tasks as an activity ledger for detached work outside the main conversation — cron executions, CLI operations, subagent spawns. OpenClaw's documentation explicitly describes tasks as "records, not schedulers," with a task lifecycle (`queued → running → terminal`) and notification delivery semantics. This provides a concrete model for agents that continue running after the initiating message, with a traceable ledger of what happened when work becomes detached.
+
+OpenClaw's persistence strategy is unusually transparent: memory is stored as plain Markdown files (`MEMORY.md` for long-term context; daily notes in `memory/YYYY-MM-DD.md`) and is reloaded automatically at session boundaries, with memory tools for searching and retrieving stored content. The optional "dreaming" feature consolidates memory via a scheduled cron job and writes review artifacts into `DREAMS.md` for human inspection, illustrating an explicit background consolidation and human review loop.
+
+OpenClaw's security guidance is explicit about the operational reality of always-on agents: session identifiers are routing selectors rather than authorization tokens, and if multiple untrusted users can message one tool-enabled agent, they should be treated as sharing delegated tool authority.
+
+*Enterprise implication: Persistence is achieved through explicit externalization of sessions, memory, and task state, rather than reliance on model context alone.*
+
+### NemoClaw: policy-enforced autonomy via sandboxing and egress control
+
+NVIDIA's NemoClaw wraps an OpenClaw deployment in a policy-enforced sandbox (OpenShell). Its architecture splits between a TypeScript plugin integrated with the OpenClaw CLI and a versioned Python blueprint that orchestrates sandbox resources — sandbox creation, policy application, and inference provider setup. OpenShell provides sandbox containers, a credential-storing gateway, inference proxying, and policy enforcement.
+
+NemoClaw's network policies are deny-by-default: only explicitly allowed endpoints are reachable, and unlisted destinations are intercepted and presented to an operator for approve/deny decisions in real time. Its security best practices document binary-scoped endpoint rules — restricting which executables may access an endpoint — with enforcement based on kernel-trusted executable paths and hashing. Each allowed endpoint is framed as a potential exfiltration path.
+
+Inference requests from within the sandbox never leave directly. The sandbox communicates with `inference.local`, and the host retains provider credentials and upstream endpoints. This structurally separates generated code execution from credential ownership, reducing the chance that an agent can trivially read tokens from its own runtime environment.
+
+*Enterprise implication: Autonomous execution is bounded by infrastructure-enforced policy, not by agent reasoning, establishing external control over side effects.*
+
+### Anthropic: managed long-horizon sessions and harness/sandbox separation
+
+Anthropic's [Claude Managed Agents documentation](https://platform.claude.com/docs/en/managed-agents/overview) positions the product as a pre-built, configurable agent harness running in managed infrastructure, designed for long-running tasks and asynchronous work. The [engineering architecture blog](https://www.anthropic.com/engineering/managed-agents) defines the architecture as virtualizing an agent into three interfaces: a durable session (append-only log), a harness (the agent loop and tool routing), and a sandbox (execution environment). Decoupling these components enables recovery from harness failure — reboot a new harness, reload the session event log, resume — and treats sandboxes as replaceable resources provisioned on demand.
+
+The same engineering documentation frames a structural security boundary: untrusted code generated by the model should not run in the same environment as credentials. Two concrete patterns are described: bundling auth with resources during sandbox initialization (e.g., repo token wired into git remote) or storing OAuth tokens in a secure vault and invoking tools through an MCP proxy that fetches credentials from the vault while the harness and sandbox never see them.
+
+Anthropic's research on [effective harnesses for long-running agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents) frames the long-running problem as bridging discrete sessions where each new session begins without memory of the previous context window. The documented approach for long-horizon coding uses an initializer session that scaffolds environment artifacts plus recurring coding sessions that make incremental progress while leaving structured artifacts (progress logs, commits) for the next session.
+
+*Enterprise implication: Decoupling session, orchestration, and execution enables long-running agents to be recoverable, scalable, and independently governed.*
+
+### Databricks: governed, stateful, schedulable agent deployments
+
+Databricks positions [Agent Bricks](https://www.databricks.com/product/artificial-intelligence/agent-bricks) as a unified platform to build and govern AI agents, explicitly describing persistent memory with Lakebase and the ability to schedule agents on recurring workflows, plus automatic capture of interactions, tool calls, and model invocations. These are direct signals that the platform is designed for always-on and scheduled operation rather than only interactive chat.
+
+Databricks documentation on [AI agent memory](https://docs.databricks.com/aws/en/generative-ai/agent-framework/stateful-agents) defines short-term memory as capturing context within a session using thread IDs and checkpointing, and long-term memory as extracting and storing key information across multiple conversations. LangGraph checkpointing backed by Lakebase provides durable state management, and a template using OpenAI Agents SDK sessions persisted to Lakebase indicates a multi-framework strategy for statefulness. The memory scaling proposal frames the agent's state as living in a persistent store — skills, knowledge, episodic and semantic memory — and positions the LLM as a swappable reasoning engine that reads the same memory store. From this pattern, we infer that long-term differentiation could accrue at the deployment level rather than the model level: the persistent context an agent accumulates over weeks of operation may become its primary asset, independent of which model powers its reasoning. This suggests a shift in differentiation from model capability to accumulated context, potentially making long-running deployments strategically valuable over time.
+
+Databricks also provides an explicit long-running mechanism for complex tasks: Supervisor Agent long-running task mode describes automatic task continuation by breaking long tasks into multiple request/response cycles, emitting `task_continue_request` events, and resuming via follow-up requests until completion. This is a concrete mechanism for agents that keep making progress across multiple cycles without timing out, and can be mapped directly to after-hours progress in enterprise workflows.
+
+Databricks documentation on [agent tools](https://docs.databricks.com/aws/en/generative-ai/agent-framework/agent-tool) describes tool integration via managed MCP servers, external MCP servers, and custom tools, with managed OAuth and a connections proxy as mechanisms to connect to third-party APIs. The build, evaluate, and deploy documentation describes operational concerns that matter for persistent systems: tracking configuration and versioning, measuring reliability through evaluation suites, and deployment with autoscaling, logging, version control, and access control. A Review App for subject matter experts to provide structured feedback closes the loop between agent output and human evaluation — a pattern that becomes essential when agents produce work products outside business hours that require review before they take effect.
+
+The governance dimension is anchored to Unity Catalog. Databricks emphasizes unified governance over agents, tools, and MCP servers with end-to-end permissions, positioning MCP as a single governed protocol for connecting tools and data with centrally managed credentials and audit trails. Unity Catalog provides the enterprise primitives — access control, lineage tracking, and credential management — that make agent tool access auditable and revocable at an organizational level rather than at an individual agent level.
+
+The Databricks partnership with Anthropic is documented via a press release describing native availability of Claude models and positioning the partnership as enabling customers to build and deploy AI agents that reason over their own data with production-level requirements for accuracy, security, and access control. This explicitly supports a Databricks-plus-Anthropic long-running agents narrative: Claude models provide the reasoning layer, Databricks provides the governance, persistence, and deployment infrastructure, and Unity Catalog provides the enterprise control plane that binds them together.
+
+*Enterprise implication: Persistent agents become operational systems when integrated with scheduling, stateful storage, and enterprise governance frameworks. Databricks demonstrates this most explicitly by treating agent deployment as a governed data platform concern rather than an application-layer concern.*
+
+## The Identity Anchor: Agents as Delegated Actors
+
+Long-running agents introduce a failure mode that does not exist in interactive systems: execution that outlives the intent that initiated it. In a request-response model, intent and execution are tightly coupled in time. In persistent systems, this coupling breaks — work continues after the initiating context has changed, expired, or become invalid. The constraint required is not improved reasoning but bounded execution, and identity-bound delegation is the mechanism that provides it. This is what makes always-on agents deployable in real organizations, not merely technically possible.
+
+### Delegated identity model
+
+Persistent agents are best modeled, we argue, as delegated actors rather than independent identities. Three roles separate concerns cleanly:
+
+The **subject** is the human principal whose intent is being carried forward. The **actor** is the agent runtime — a workload identity — performing tool calls on behalf of the subject. The **delegation chain** is the cryptographic and policy-bound record that the actor is permitted to act for the subject, scoped to a time window, audience, and action set.
+
+OAuth 2.0 Token Exchange ([RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693)) defines a Security Token Service style protocol for exchanging tokens, explicitly supporting delegation and impersonation semantics. Identity vendors are operationalizing this pattern: Ping Identity's materials frame "delegation instead of impersonation," describing tokens that carry both the human subject identity and the agent identity via `act`/`may_act` claims, preserving an auditable chain of custody for downstream authorization decisions. Microsoft Entra describes agent identities (currently in preview) as specialized identity constructs for AI agents, arguing that identity models designed for humans and applications are insufficient as organizations deploy autonomous systems at enterprise scale.
+
+### What identity-bound governance enables
+
+From the vendor-documented patterns analyzed in this paper, identity-bound delegation enables four properties required for always-on systems.
+
+**Attribution.** Every tool call is traceable to an initiating subject, even when execution occurs asynchronously or outside working hours. This resolves the auditability gap that emerges when work happens without a human present.
+
+**Revocation.** Execution can be halted when intent changes. Long-running agents do not require explicit shutdown; their authority can expire or be withdrawn. The OpenID CAEP specification defines continuous access evaluation signals intended to attenuate access for human or robotic users, devices, sessions, and applications. Microsoft Entra describes CAE as an industry standard based on CAEP with near real-time enforcement goals.
+
+**Scoped authority.** Work can be assigned to agents without granting permanent or shared credentials. Authority is scoped to the specific task and context, preventing what we term the "authorization outlives intent" failure mode — a risk pattern consistent with the identity concerns Okta raises in its agent token exchange guidance for always-on agents.
+
+**Isolation.** Agents operating in shared environments do not inherit shared authority. Each task remains bound to its originating identity and scope, addressing the multi-user authority collapse risk documented in OpenClaw's security guidance.
+
+These properties are not enhancements. They are prerequisites for allowing agents to operate continuously within enterprise systems. Identity-bound governance constrains execution, not cognition — it does not improve model reasoning or guarantee correctness of outputs. Its role is to ensure that when agents act, they do so within enforceable and observable boundaries.
+
+## Reference Architecture
+
+The architectural patterns observed across current systems can, we propose, be unified by introducing identity and delegation as first-class components. Persistence, execution, and governance are not independent concerns. They are coupled through the requirement that long-running work remains bound to its originating intent.
+
+The following reference architecture organizes persistent agent infrastructure into four planes.
+
+### Architecture diagram
+
+```mermaid
+flowchart TB
+  subgraph IAM["Identity & session plane"]
+    IdP["IdP + Conditional Access<br/>SSO, MFA, device posture"]
+    Sess["Session policy<br/>lifetime + reauth cadence"]
+    CAE["Continuous evaluation<br/>CAE/CAEP signals"]
+  end
+
+  subgraph Delegation["Delegation & token plane"]
+    STS["Token exchange / OBO<br/>RFC 8693"]
+    Vault["Token vault<br/>rotation + revocation"]
+  end
+
+  subgraph Agent["Persistent agent plane"]
+    Runtime["Agent runtime<br/>planner + workers"]
+    Memory["Persistent context store<br/>session log + memory + checkpoints"]
+    Gateway["Tool gateway<br/>single egress"]
+    Policy["Policy engine<br/>allow / approve / block"]
+    Audit["Audit + traces"]
+  end
+
+  subgraph Tools["Enterprise tool plane"]
+    APIs["Internal APIs / systems"]
+    Channels["Enterprise channels<br/>chat / tickets / email"]
+  end
+
+  IdP --> Sess
+  Sess --> STS
+  CAE --> IdP
+  CAE --> Vault
+
+  STS --> Vault
+  Vault --> Runtime
+
+  Runtime <--> Memory
+  Runtime --> Gateway
+  Channels --> Runtime
+  Gateway --> Policy
+  Policy -->|allow| APIs
+  Policy -->|approve| IdP
+  Policy -->|block| Audit
+  APIs --> Runtime
+
+  Runtime --> Audit
+  Gateway --> Audit
+  Policy --> Audit
+```
+
+### Component mappings to citable building blocks
+
+**Identity & session plane.** User authentication flows through existing IdP infrastructure. Okta's global session policies explicitly support prompting frequency — setting the time before prompting for another challenge — which provides a native control plane for bounded agent session renewal. Google's session controls configure how often users must re-authenticate and whether full login, password-only, or hardware security key is required, directly supporting agent check-in renewal cadences. Microsoft Entra's Conditional Access policies enforce device compliance gates (via Intune) and granular step-up authentication using authentication context, enabling device-posture-gated agent session initiation and renewal. These are not new infrastructure requirements. They are existing enterprise controls extended to cover a new class of workload — the persistent agent.
+
+**Delegation & token plane.** A token exchange or on-behalf-of flow mints a downscoped delegated token for the agent runtime. Okta documents OBO token exchange as retaining user context in requests to downstream services. Okta's agent-specific token exchange guidance (Early Access) explicitly positions token exchange as the mechanism to let AI agents access protected resources on behalf of authenticated users. Token Exchange ([RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693)) provides the protocol backbone as a standards-based mechanism for exchanging tokens, explicitly supporting delegation and impersonation use cases. Ping Identity's delegation framing embeds both identities in the token — the human subject (`sub`) and the agent actor (`act`/`may_act`) — preserving an auditable chain of custody for downstream authorization decisions.
+
+Refresh token rotation (documented by both Okta and Auth0) minimizes replay risk and reduces the blast radius of stolen tokens in long-lived delegated systems. Auth0's Continuous Session Protection provides customizable session and refresh token management controls for enterprise security requirements, including revocation and tailored lifetimes.
+
+The token vault stores credentials outside agent memory and execution environments, implementing the structural credential isolation described in Anthropic's managed agents documentation. This is not cosmetic: untrusted generated code can access credentials in the same container environment, and the structural fix is to keep tokens unreachable from the sandbox. Two concrete patterns are documented: bundling auth with resources during sandbox initialization (e.g., repo token wired into git remote) or storing OAuth tokens in a secure vault and invoking tools through an MCP proxy that fetches credentials from the vault while the harness and sandbox never see them.
+
+**Persistent agent plane.** The durable session log maps to Anthropic's session as an append-only log outside the harness and sandbox, retrievable as an event stream. This enables recovery from harness failure: reboot a new harness, reload the session event log, resume. Task records and provenance map to OpenClaw's background task ledger for detached work — cron runs, subagent spawns, CLI runs — where tasks function as traceable activity logs rather than execution triggers (described in OpenClaw's documentation as "records, not schedulers"), with explicit lifecycle tracking (`queued → running → terminal`) and notification delivery semantics. Memory and checkpoints map to Databricks agent memory with Lakebase as a durable store (short-term via thread IDs and checkpointing, long-term across sessions) and to OpenClaw's file-backed `MEMORY.md` persistence with optional scheduled consolidation via dreaming jobs. The policy/approval gate maps to NemoClaw's operator approval for unlisted network destinations and to Anthropic's per-action permissions model (always allow / needs approval / block).
+
+**Enterprise tool plane.** All tool access is mediated through a gateway and policy enforcement point. Continuation maps to Databricks' task continuation mechanism for long tasks exceeding timeouts (`task_continue_request` / `task_continue_response` loops) and to Anthropic's asynchronous long-running work positioning. AWS AgentCore Gateway positions itself as a secure connectivity layer converting APIs and Lambda functions into MCP-compatible tools reachable through gateway endpoints. Databricks' tool integration via managed MCP servers with managed OAuth and a connections proxy provides a governed variant where credential management and access control are centralized in Unity Catalog rather than managed per-agent.
+
+### Operational flows
+
+**Session initiation and delegation.** A user authenticates via SSO under existing policies — MFA, conditional access, device posture. Okta global session policies explicitly support prompting frequency, and Google session controls explicitly support reauthentication methods and intervals. A token exchange or OBO flow mints a downscoped delegated token for the agent runtime. Okta documents OBO token exchange as preserving user context in downstream requests. The agent begins work with bounded authority that is traceable to the initiating user, and the delegated token encodes both who requested (subject) and what acts (actor) for downstream authorization decisions.
+
+**Renewable sessions and continuous evaluation.** The delegated token is short-lived; renewals occur through controlled exchanges. CAEP defines continuous updates enabling receivers to attenuate access to sessions, devices, and robotic users. Microsoft Entra describes CAE as an industry standard based on CAEP with near-real-time enforcement goals, though with possible latency due to event propagation. Practically, this enables revocation on critical events — risk changes, device posture changes, policy updates — rather than waiting for access token expiry. A deployment should measure end-to-end revocation latency to ensure the governance expectation is met.
+
+**Token vaulting and credential lifecycle.** Refresh tokens and delegated credentials are stored in a dedicated token vault rather than in agent memory or local files. Refresh token rotation guidance from Okta and Auth0 highlights rotation behavior and revocation implications as first-class controls. OAuth Security Best Current Practice ([RFC 9700](https://datatracker.ietf.org/doc/rfc9700/)) updates threat modeling for broad OAuth usage and provides a suitable baseline for vault design. The vault is a structural control: it ensures that even if the agent's execution environment is compromised, credentials are not directly accessible.
+
+**Tool execution via gateway and policy engine.** All tool calls traverse a single gateway that enforces allow/approve/block decisions, records traces, and integrates step-up authentication or human review where needed. The gateway is the enforcement boundary: the agent cannot bypass it. OpenAI's guardrails documentation defines human review as a runtime pause that gates sensitive tool actions, supporting enforceable approvals without breaking workflow continuity. AWS AgentCore Gateway and Ping Identity's agent gateway framing each implement this as a first-class architecture layer — a security proxy validating delegation tokens and enforcing runtime authorization in front of protected resources. NemoClaw's deny-by-default egress implements the same principle at the environment boundary, intercepting unlisted destinations and surfacing them for operator approval in real time.
+
+**After-hours progress.** The user initiates a task, the system produces a task record with provenance (who, why, when), and the harness continues running the work loop until the next check-in point or approval gate, emitting updates back to the initiating user. The delegated token's lifetime and renewal requirements ensure that work does not continue indefinitely without governance checks. Anthropic's long-running harness research describes this explicitly: an initializer session scaffolds environment artifacts, then recurring coding sessions make incremental progress while leaving structured artifacts (progress logs, commits) for the next session. The system is designed for multi-session work spanning hours or days, with each session's output serving as input for the next.
+
+**Observability and audit.** Every tool call, approval decision, and state transition is recorded in an event log or trace store. OpenAI's Agents SDK tracing collects a record of events including tool calls and guardrails, supporting auditability. Databricks emphasizes capturing every interaction and tool call for monitoring, and provides evaluation loops via LLM judges and custom metrics on traces. OpenClaw's background task ledger frames detached work as records with explicit lifecycle tracking and notification semantics. These converge on a unified pattern: persistent agents require persistent ledgers with auditability, because asynchronous work must be observable to be governable.
+
+## The Productivity Hypothesis
+
+The productivity implications of long-running agents do not arise from faster responses. They arise from temporal decoupling.
+
+Interactive systems are bounded by human working time. Persistent systems are bounded by system constraints — compute, API rate limits, and policy gates — rather than by whether a human is actively watching.
+
+### The core mechanism: cycle-time reduction
+
+The primary mechanism is cycle-time reduction. In workflows dominated by latency and iteration, significant time is spent waiting: for builds, for test results, for data retrieval, or for intermediate decisions. Long-running agents convert this idle time into execution time by continuing work between human interactions. The result is not necessarily faster individual steps, but shorter end-to-end completion time.
+
+From the vendor documentation analyzed in this paper, a testable productivity hypothesis emerges:
+
+> When agents can continue making incremental progress between human check-ins, they can shorten end-to-end cycle time for multi-step workflows by converting idle and wait time into progress time.
+
+This hypothesis is strongest for workflows dominated by latency and iteration: running tests, waiting for builds, collecting data, executing multi-step tool chains, or performing repeated review and triage. The long-running harness strategy in Anthropic's research explicitly treats long-horizon coding as incremental progress across sessions, with artifacts for the next session to reduce rework. Databricks' Supervisor long-task mode similarly treats long tool-call sequences as resumable across cycles rather than failing at a timeout boundary.
+
+### Coverage, not speed
+
+The productivity model implied by persistent agents is fundamentally different from the interactive assistance model.
+
+| Model | Constraint | Productivity lever |
+|---|---|---|
+| Human + interactive copilot | Bounded by human working hours | Individual task speed |
+| Human + always-on agents | Bounded by system constraints | Temporal coverage and throughput |
+
+The argument is that productivity equals time multiplied by coverage, not speed alone. A developer who dispatches three coding agents at end-of-day — one running tests against a refactored module, one collecting benchmark data, one triaging a backlog of lint warnings — returns the next morning to completed work products rather than a cold start. The developer's own speed has not changed. The workflow's cycle time has compressed because idle hours became execution hours.
+
+A common pattern where this effect is most visible is CI/CD pipelines, where build, test, and validation steps are inherently asynchronous. Persistent agents can orchestrate these steps continuously — triggering the next stage as soon as the previous one completes, handling transient failures with retries, and collecting results for human review — reducing idle time between stages without requiring human re-initiation at each step.
+
+### Empirical constraints
+
+This effect is not universal. Tasks requiring continuous human judgment or high-context decision-making do not benefit from asynchronous continuation. Empirical evidence on AI-assisted productivity remains mixed, suggesting that gains depend on workflow structure rather than tool capability alone.
+
+A field experiment analysis of GitHub Copilot ([Cui et al., MIT GenAI](https://mit-genai.pubpub.org/pub/v5iixksv)) reports suggestive increases in pull requests completed per week in some organizational settings, though the authors emphasize limitations such as compliance and precision. Conversely, a randomized controlled trial of experienced open-source developers ([Becker et al., METR, arXiv:2507.09089, July 2025](https://metr.org/blog/2025-07-10-early-2025-ai-experienced-os-dev-study/)) reported that allowing AI tools increased completion time by 19%, contradicting developer expectations.
+
+A paper arguing for beyond-work-hours productivity is therefore strongest when it frames the claim as enabled by long-running architectures documented by vendors and requiring enterprise evaluation metrics — cycle time, PR lead time, defect rate, human review load — rather than relying on sentiment or self-reported speed. The productivity hypothesis is testable. It has not yet been tested at enterprise scale.
+
+## Comparison Table
+
+The following table compares representative systems across the architectural dimensions analyzed in this paper. "Unspecified" indicates the relevant primary documentation does not clearly describe the attribute.
+
+| Solution | Persistence model | Identity anchoring | Policy / gateway | Deployment | Maturity |
+|---|---|---|---|---|---|
+| **OpenClaw** | File-backed memory (`MEMORY.md`, daily notes) loaded automatically; gateway-centric architecture | Unspecified (security guidance: routing keys are not authorization) | Gateway is control plane; exec approvals as intent guardrails | Self-hosted (MIT) | Active OSS |
+| **NemoClaw** | Persistent sandbox workspace files; explicit sandbox policy model | Unspecified | Deny-by-default egress; operator approval on unlisted destinations; OpenShell policy layers | Self-hosted (Apache-2.0) | Alpha / early preview |
+| **Anthropic Managed Agents** | Append-only session log; harness/sandbox separation; session survives harness failure | Credential vaulting via MCP proxy; structural sandbox isolation | Per-action permissions (allow/approve/block); sandboxed execution | Managed service | Production documentation |
+| **Databricks Agent Bricks** | Lakebase-backed memory; thread checkpointing; long-term cross-session memory | IAM-centric; Unity Catalog governance | MCP servers; managed OAuth; connections proxy; task continuation | Managed service | Production cloud service |
+| **LangGraph** | Built-in checkpoint persistence; state saved at each step, organized into threads | Unspecified | HITL via persistence; gateway primitives unspecified | Self-hosted (MIT) | Mature OSS |
+| **OpenAI Agents SDK** | Application-defined persistence; SDK provides orchestration, tracing, approvals | Unspecified | Guardrails + human review; tracing and handoffs as first-class primitives | Self-hosted (MIT) | Official vendor SDK |
+| **AWS Bedrock Agents** | Managed construct; tool actions formalized via action groups | IAM-centric | Action groups; AgentCore Gateway as tool connectivity layer | AWS managed service | Production |
+
+Two patterns emerge from this comparison. First, based on the documentation surveyed, identity anchoring appears to be the least mature dimension across the landscape — most systems treat it as an external concern rather than a first-class architectural component, and several major frameworks leave it entirely unspecified. Second, policy and gateway primitives are increasingly built into agent platforms rather than bolted on, suggesting convergence toward tool-boundary governance as a baseline expectation.
+
+## Conclusion
+
+Persistent agents are a structural evolution of enterprise automation. They extend work across time, retain durable context, and act through tools. The enterprise control problem is not whether agents are safe in the abstract, but whether agent autonomy is bounded by renewable sessions, attributable to human intent, and enforced at unbypassable control points.
+
+This paper has argued that always-on agents become deployable — not merely technically possible — when three conditions are met. First, persistence is externalized: sessions, memory, and task state live outside the model context window in durable, inspectable stores. The evidence from OpenClaw, Anthropic, and Databricks demonstrates convergence on this pattern. Second, execution is identity-bound: every action traces to a human subject through a delegation chain that can be audited, scoped, and revoked. Identity standards (RFC 8693, CAEP) and vendor implementations (Okta, Microsoft Entra, Ping Identity) provide the protocol infrastructure. Third, tool boundaries are governed: a gateway and policy engine mediate all side effects, enforcing allow/approve/block decisions independently of the agent's reasoning.
+
+These three conditions map directly to the series formula. Specification quality defines what an agent should do. Loop autonomy defines how it executes. Persistent context management sustains execution across time. And identity-bound governance ensures that sustained execution remains aligned with human intent — not through prompt discipline, but through structural enforcement.
+
+The productivity hypothesis — that always-on agents compress cycle time by converting idle hours into execution hours — is grounded in the architectural capabilities described in this paper, not in empirical proof of enterprise-scale gains. It is, however, not yet validated at enterprise scale. Organizations evaluating persistent agent deployments should instrument for cycle time, throughput, and review load rather than relying on self-reported productivity gains.
+
+The transition from interactive copilots to persistent agents is not incremental. It is a shift from tools to infrastructure. Identity-bound governance is what makes that shift viable.
+
+---
+
+## References
+
+### Agent Platforms & Infrastructure
+
+- Anthropic. "Claude Managed Agents Overview." https://platform.claude.com/docs/en/managed-agents/overview
+- Anthropic. "Managed Agents Architecture." https://www.anthropic.com/engineering/managed-agents
+- Anthropic. "Effective Harnesses for Long-Running Agents." https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents
+- Anthropic. "Trustworthy Agents in Practice." https://www.anthropic.com/research/trustworthy-agents
+- OpenClaw. "Session Management." https://docs.openclaw.ai/concepts/session
+- OpenClaw. "Background Tasks." https://docs.openclaw.ai/automation/tasks
+- OpenClaw. "Memory Overview." https://docs.openclaw.ai/concepts/memory
+- OpenClaw. "Security Model." https://docs.openclaw.ai/gateway/security
+- NVIDIA. "NemoClaw Architecture." https://docs.nvidia.com/nemoclaw/latest/reference/architecture.html
+- NVIDIA. "NemoClaw Network Policies." https://docs.nvidia.com/nemoclaw/latest/reference/network-policies.html
+- NVIDIA. "OpenShell Security Best Practices." https://docs.nvidia.com/openshell/security/best-practices
+- Databricks. "Agent Bricks." https://www.databricks.com/product/artificial-intelligence/agent-bricks
+- Databricks. "AI Agent Memory." https://docs.databricks.com/aws/en/generative-ai/agent-framework/stateful-agents
+- Databricks. "Agent Tools." https://docs.databricks.com/aws/en/generative-ai/agent-framework/agent-tool
+- AWS. "Agentic AI Security Best Practices." https://docs.aws.amazon.com/prescriptive-guidance/latest/agentic-ai-security/best-practices.html
+- AWS. "Bedrock Agents Action Groups." https://docs.aws.amazon.com/bedrock/latest/userguide/agents-action-create.html
+- AWS. "AgentCore Gateway." https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway.html
+
+### Identity & Governance
+
+- IETF. "OAuth 2.0 Token Exchange." RFC 8693. https://datatracker.ietf.org/doc/html/rfc8693
+- IETF. "OAuth 2.0 Security Best Current Practice." RFC 9700. https://datatracker.ietf.org/doc/rfc9700/
+- OpenID Foundation. "CAEP 1.0 (Continuous Access Evaluation)." https://openid.net/specs/openid-caep-1_0-final.html
+- Microsoft. "Continuous Access Evaluation (CAE)." https://learn.microsoft.com/en-us/entra/identity/conditional-access/concept-continuous-access-evaluation
+- Microsoft. "Agent Identities (Entra Agent ID)." https://learn.microsoft.com/en-us/entra/agent-id/what-are-agent-identities
+- Microsoft. "Conditional Access Authentication Context (Step-Up)." https://learn.microsoft.com/en-us/entra/identity-platform/developer-guide-conditional-access-authentication-context
+- Okta. "Global Session Policies." https://help.okta.com/oie/en-us/content/topics/identity-engine/policies/about-okta-sign-on-policies.htm
+- Okta. "Device Assurance." https://help.okta.com/oie/en-us/content/topics/identity-engine/devices/device_assurance.htm
+- Okta. "On-Behalf-Of Token Exchange." https://developer.okta.com/docs/guides/set-up-token-exchange/main/
+- Okta. "AI Agent Token Exchange (Early Access)." https://developer.okta.com/docs/guides/ai-agent-token-exchange/-/main/
+- Google. "Context-Aware Access." https://docs.cloud.google.com/access-context-manager/docs/securing-console-and-apis
+- Google. "Session Controls for Re-authentication." https://docs.google.com/access-context-manager/docs/session-controls-for-reauthentication
+- Ping Identity. "Identity for AI." https://cdn-docs.pingidentity.com/archive/pdf/identity-for-ai/identity_for_ai.pdf
+- Auth0. "Continuous Session Protection." https://auth0.com/docs/secure/continuous-session-protection
+- Auth0. "Refresh Token Rotation." https://auth0.com/docs/secure/tokens/refresh-tokens/configure-refresh-token-rotation
+
+### Empirical Productivity Research
+
+- Cui et al. "The Effects of Generative AI on High Skilled Work: Evidence from Three Field Experiments with Software Developers." https://mit-genai.pubpub.org/pub/v5iixksv
+- Becker et al. "Measuring the Impact of Early-2025 AI on Experienced Open-Source Developer Productivity." arXiv:2507.09089, July 2025. https://metr.org/blog/2025-07-10-early-2025-ai-experienced-os-dev-study/
+
+### Related Research on This Site
+
+- [The Specification Layer](/articles/specification-layer/)
+- [The Autonomous Agents Loop](/articles/autonomous-agents-loop/)
+- [Autonomous AI Agents: Execution Loops vs Interactive Assistance](/papers/autonomous-agents/)
+- [Agentic Development Tools and Execution Architectures](/papers/agentic-tools/)
+- [Spec-Driven Development Framework Patterns](/papers/sdd-frameworks/)
+
+---
+
+*This paper is Part 3 of a series on scaling agentic development for enterprise teams. Part 1, [The Specification Layer](/articles/specification-layer/), covers why specifications are the missing enterprise scaling strategy. Part 2, [The Autonomous Agents Loop](/articles/autonomous-agents-loop/), covers why autonomous execution loops outperform interactive assistance. For the empirical evidence base on autonomous execution, see the companion paper [Autonomous AI Agents: Execution Loops vs Interactive Assistance](/papers/autonomous-agents/).*
+
+*This paper is part of an ongoing research project tracking AI tooling, software engineering practices, and cross-functional workflows at [daviddaniel.tech/research](https://daviddaniel.tech/research).*
+
+---
+
+*This paper was created with AI assistance. Sources include primary vendor documentation from Anthropic (Managed Agents, long-running harness research), OpenClaw, NVIDIA NemoClaw, Databricks (Agent Bricks, agent memory, agent tools), and AWS (Bedrock, AgentCore Gateway); identity standards and vendor guidance from IETF (RFC 8693, RFC 9700), OpenID Foundation (CAEP), Microsoft Entra, Okta, Google, Auth0, and Ping Identity; and empirical productivity research from Cui et al. (MIT GenAI) and Becker et al. (METR, July 2025). Data as of April 2026.*

--- a/docs/papers/always-on-agents/index.md
+++ b/docs/papers/always-on-agents/index.md
@@ -15,11 +15,11 @@ date: 2026-04-13
 
 ---
 
-## Executive Summary
+## Abstract
 
 Enterprise agent systems are converging on a long-running shape: durable state outside a single model context window, asynchronous continuation across multiple request/response cycles, and enforceable boundaries where text becomes action. Multiple independent vendor ecosystems now describe long-horizon agents as a first-class deployment target rather than an edge case.
 
-This convergence introduces a structural constraint. This paper argues that enterprise productivity gains from AI are most likely to emerge when work is delegated to long-running agents operating asynchronously under identity-bound governance — though this hypothesis has not yet been validated at enterprise scale. Without mechanisms to bind autonomous execution to human intent over time, persistent agents remain confined to interactive use — bounded by human working hours and direct supervision.
+This convergence introduces a structural constraint. This paper argues that enterprise productivity gains from AI are most likely to emerge when work is delegated to long-running agents operating asynchronously under identity-bound governance, though this hypothesis has not yet been validated at enterprise scale. Without mechanisms to bind autonomous execution to human intent over time, persistent agents remain confined to interactive use, bounded by human working hours and direct supervision.
 
 The constraint required is not improved model reasoning but bounded execution. Identity-bound delegation provides this by ensuring that all agent actions remain attributable, scoped, and revocable. This paper provides a deployment-oriented taxonomy of persistent agent architectural patterns, a reference architecture that anchors agents to identity-scoped sessions with tool-boundary governance, and a productivity hypothesis grounded in cycle-time reduction rather than task-speed improvement.
 
@@ -27,7 +27,7 @@ The analysis draws on primary documentation from OpenClaw, NVIDIA NemoClaw, Anth
 
 ## Introduction
 
-The first two parts of this series established a formula for enterprise AI scaling: specification quality × loop autonomy × context management = reliable output at scale. Part 1 argued that machine-readable specifications are the missing foundation for agentic scaling. Part 2 argued that longer autonomous execution with multi-agent context management outperforms interactive assistance. This paper extends both arguments into persistent territory: what happens when autonomous execution persists across sessions, hours, and organizational boundaries.
+The first two parts of this series proposed a framework for enterprise AI scaling, identifying three interdependent factors that together determine reliable output at scale: specification quality, loop autonomy, and context management. Part 1 argued that machine-readable specifications are the missing foundation for agentic scaling. Part 2 argued that longer autonomous execution with multi-agent context management outperforms interactive assistance. This paper extends both arguments into persistent territory: what happens when autonomous execution persists across sessions, hours, and organizational boundaries.
 
 Persistent agents represent a shift in the shape of enterprise automation. Instead of request/response interaction constrained to a chat session, persistent agents retain durable context and produce durable work products across time: plans, tickets, diffs, runbooks, approvals, and tool-executed side effects. Anthropic's Claude Managed Agents is explicitly positioned as "best for long-running tasks and asynchronous work," and its engineering documentation formalizes long-running operation as a durable session log plus a harness that can resume after failure and a sandboxed execution layer that can be replaced without losing the session. Databricks is productizing stateful and long-running agent operation in a governed data platform: Agent Bricks explicitly supports scheduling agents on recurring workflows, capturing tool calls and invocations, and giving agents persistent memory via Lakebase. OpenClaw provides an inspectable open-source example of always-on operation with explicit session lifecycle policies and file-backed memory persistence.
 
@@ -35,7 +35,7 @@ Agents in this context are not interactive tools. They are delegated execution c
 
 This shift introduces a structural constraint. As execution persists beyond a single interaction, actions can outlive the intent that initiated them. This creates a new class of failure mode: systems that continue operating correctly according to their instructions, but incorrectly relative to current human intent. A coding agent that continues refactoring a module after priorities shifted overnight. A triage agent that keeps applying a policy that was updated during the previous business day. A review agent that approves changes using criteria that were superseded by a new compliance requirement.
 
-The central question for enterprise adoption is therefore not only how agents execute, but how their execution remains attributable, scoped, and revocable over time. The enterprise question is whether always-on agent behavior will arrive inside the existing governance perimeter — identity, device posture, audit, approvals — or outside it, through ad hoc tokens, unmanaged chat surfaces, and weak attribution.
+The central question for enterprise adoption is therefore not only how agents execute, but how their execution remains attributable, scoped, and revocable over time. The enterprise question is whether always-on agent behavior will arrive inside the existing governance perimeter (identity, device posture, audit, approvals) or outside it, through ad hoc tokens, unmanaged chat surfaces, and weak attribution.
 
 Persistent agents are not constrained by execution capability. They are constrained by the ability to bind that execution to human intent over time.
 
@@ -49,13 +49,13 @@ These archetypes should not be interpreted as variations of a single agent syste
 
 ### Review agents
 
-Review agents focus on evaluating artifacts produced by humans or other agents: code diffs, pull requests, design docs, compliance checklists, incident postmortems, and vendor contracts. Review behavior appears as an explicit control surface in multiple ecosystems. Databricks' Review App enables subject matter experts to review interactions and feed monitoring and evaluation loops. OpenClaw's optional "dreaming" consolidation writes output into `DREAMS.md` for human inspection. NemoClaw requires operator approval for new network destinations during runtime. Anthropic frames per-action permissions and approval tiers as the control mechanism for trustworthy agents — always allow, needs approval, or block — which provides a natural review-agent policy substrate.
+Review agents focus on evaluating artifacts produced by humans or other agents: code diffs, pull requests, design docs, compliance checklists, incident postmortems, and vendor contracts. Review behavior appears as an explicit control surface in multiple ecosystems. Databricks' Review App enables subject matter experts to review interactions and feed monitoring and evaluation loops. OpenClaw's optional "dreaming" consolidation writes output into `DREAMS.md` for human inspection. NemoClaw requires operator approval for new network destinations during runtime. Anthropic frames per-action permissions and approval tiers as the control mechanism for trustworthy agents (always allow, needs approval, or block), which provides a natural review-agent policy substrate.
 
 Review agents are distinguished by their read-heavy authority profile and their role as quality gates within larger workflows. Their persistence requirement is primarily context continuity: retaining knowledge of what was previously reviewed, what standards apply, and what exceptions have been granted.
 
 ### Coding agents
 
-Coding agents perform incremental changes in version-controlled repositories, with tight tool boundaries and a loop of edit, build/test, observe, and iterate. Anthropic's tool combinations documentation defines the canonical coding loop as `text_editor` + `bash`, and its long-running harness research describes an initializer session plus repeated coding sessions that make incremental progress while leaving structured artifacts — progress logs, commit history — for the next session.
+Coding agents perform incremental changes in version-controlled repositories, with tight tool boundaries and a loop of edit, build/test, observe, and iterate. Anthropic's tool combinations documentation defines the canonical coding loop as `text_editor` + `bash`, and its long-running harness research describes an initializer session plus repeated coding sessions that make incremental progress while leaving structured artifacts (progress logs, commit history) for the next session.
 
 Coding agents are distinguished by their write-heavy but version-controlled authority profile. The version control system provides a natural audit trail and rollback mechanism, making this archetype one of the safest for extended autonomous operation.
 
@@ -67,13 +67,13 @@ Continuation agents are distinguished by their temporal persistence requirement:
 
 ### Governed integration agents
 
-Governed integration agents are specialized to operate against enterprise data and systems — databases, ticketing, CI/CD, CRM — with explicit tool governance. Databricks emphasizes unified governance over agents, tools, and MCP servers with end-to-end permissions, positioning MCP as a single governed protocol for connecting tools and data with centrally managed credentials and audit trails. NemoClaw demonstrates a strict variant: even with tool capability, network egress must be explicitly allowed and can be restricted by executable identity and method/path rules.
+Governed integration agents are specialized to operate against enterprise data and systems (databases, ticketing, CI/CD, CRM) with explicit tool governance. Databricks emphasizes unified governance over agents, tools, and MCP servers with end-to-end permissions, positioning MCP as a single governed protocol for connecting tools and data with centrally managed credentials and audit trails. NemoClaw demonstrates a strict variant: even with tool capability, network egress must be explicitly allowed and can be restricted by executable identity and method/path rules.
 
 Governed integration agents are distinguished by their deep coupling with enterprise systems and the corresponding requirement for fine-grained authorization at every tool boundary.
 
 ### Archetype interactions
 
-These archetypes are not isolated. A realistic enterprise deployment might involve a continuation agent that dispatches coding agents for implementation work, with review agents evaluating the output before governed integration agents push changes to production systems. The "always-on" capability is not one agent doing everything, but an ecosystem of specialized supervised agents that interact through durable artifacts — tasks, repos, tickets — and explicit approval gates.
+These archetypes are not isolated. A realistic enterprise deployment might involve a continuation agent that dispatches coding agents for implementation work, with review agents evaluating the output before governed integration agents push changes to production systems. The "always-on" capability is not one agent doing everything, but an ecosystem of specialized supervised agents that interact through durable artifacts (tasks, repos, tickets) and explicit approval gates.
 
 Architectures that support asynchronous continuation and identity-bound delegation make it feasible for a single human to supervise multiple concurrent agent tasks, each progressing independently between review cycles.
 
@@ -83,9 +83,9 @@ The following analysis draws on primary vendor documentation to map how current 
 
 ### OpenClaw: sessions, background tasks, and scheduled persistence
 
-OpenClaw documents a session routing model where inbound messages are routed to sessions based on origin — direct messages, group chats, rooms/channels, cron jobs, and webhooks. The same documentation defines explicit session lifecycle policies (daily reset by default, optional idle reset, manual reset) and describes session state as gateway-owned and stored with transcripts on disk. This makes session boundaries configurable and explicit rather than implicit in a UI.
+OpenClaw documents a session routing model where inbound messages are routed to sessions based on origin: direct messages, group chats, rooms/channels, cron jobs, and webhooks. The same documentation defines explicit session lifecycle policies (daily reset by default, optional idle reset, manual reset) and describes session state as gateway-owned and stored with transcripts on disk. This makes session boundaries configurable and explicit rather than implicit in a UI.
 
-OpenClaw also defines background tasks as an activity ledger for detached work outside the main conversation — cron executions, CLI operations, subagent spawns. OpenClaw's documentation explicitly describes tasks as "records, not schedulers," with a task lifecycle (`queued → running → terminal`) and notification delivery semantics. This provides a concrete model for agents that continue running after the initiating message, with a traceable ledger of what happened when work becomes detached.
+OpenClaw also defines background tasks as an activity ledger for detached work outside the main conversation: cron executions, CLI operations, subagent spawns. OpenClaw's documentation explicitly describes tasks as "records, not schedulers," with a task lifecycle (`queued → running → terminal`) and notification delivery semantics. This provides a concrete model for agents that continue running after the initiating message, with a traceable ledger of what happened when work becomes detached.
 
 OpenClaw's persistence strategy is unusually transparent: memory is stored as plain Markdown files (`MEMORY.md` for long-term context; daily notes in `memory/YYYY-MM-DD.md`) and is reloaded automatically at session boundaries, with memory tools for searching and retrieving stored content. The optional "dreaming" feature consolidates memory via a scheduled cron job and writes review artifacts into `DREAMS.md` for human inspection, illustrating an explicit background consolidation and human review loop.
 
@@ -95,9 +95,9 @@ OpenClaw's security guidance is explicit about the operational reality of always
 
 ### NemoClaw: policy-enforced autonomy via sandboxing and egress control
 
-NVIDIA's NemoClaw wraps an OpenClaw deployment in a policy-enforced sandbox (OpenShell). Its architecture splits between a TypeScript plugin integrated with the OpenClaw CLI and a versioned Python blueprint that orchestrates sandbox resources — sandbox creation, policy application, and inference provider setup. OpenShell provides sandbox containers, a credential-storing gateway, inference proxying, and policy enforcement.
+NVIDIA's NemoClaw wraps an OpenClaw deployment in a policy-enforced sandbox (OpenShell). Its architecture splits between a TypeScript plugin integrated with the OpenClaw CLI and a versioned Python blueprint that orchestrates sandbox resources: sandbox creation, policy application, and inference provider setup. OpenShell provides sandbox containers, a credential-storing gateway, inference proxying, and policy enforcement.
 
-NemoClaw's network policies are deny-by-default: only explicitly allowed endpoints are reachable, and unlisted destinations are intercepted and presented to an operator for approve/deny decisions in real time. Its security best practices document binary-scoped endpoint rules — restricting which executables may access an endpoint — with enforcement based on kernel-trusted executable paths and hashing. Each allowed endpoint is framed as a potential exfiltration path.
+NemoClaw's network policies are deny-by-default: only explicitly allowed endpoints are reachable, and unlisted destinations are intercepted and presented to an operator for approve/deny decisions in real time. Its security best practices document binary-scoped endpoint rules (restricting which executables may access an endpoint) with enforcement based on kernel-trusted executable paths and hashing. Each allowed endpoint is framed as a potential exfiltration path.
 
 Inference requests from within the sandbox never leave directly. The sandbox communicates with `inference.local`, and the host retains provider credentials and upstream endpoints. This structurally separates generated code execution from credential ownership, reducing the chance that an agent can trivially read tokens from its own runtime environment.
 
@@ -105,7 +105,7 @@ Inference requests from within the sandbox never leave directly. The sandbox com
 
 ### Anthropic: managed long-horizon sessions and harness/sandbox separation
 
-Anthropic's [Claude Managed Agents documentation](https://platform.claude.com/docs/en/managed-agents/overview) positions the product as a pre-built, configurable agent harness running in managed infrastructure, designed for long-running tasks and asynchronous work. The [engineering architecture blog](https://www.anthropic.com/engineering/managed-agents) defines the architecture as virtualizing an agent into three interfaces: a durable session (append-only log), a harness (the agent loop and tool routing), and a sandbox (execution environment). Decoupling these components enables recovery from harness failure — reboot a new harness, reload the session event log, resume — and treats sandboxes as replaceable resources provisioned on demand.
+Anthropic's [Claude Managed Agents documentation](https://platform.claude.com/docs/en/managed-agents/overview) positions the product as a pre-built, configurable agent harness running in managed infrastructure, designed for long-running tasks and asynchronous work. The [engineering architecture blog](https://www.anthropic.com/engineering/managed-agents) defines the architecture as virtualizing an agent into three interfaces: a durable session (append-only log), a harness (the agent loop and tool routing), and a sandbox (execution environment). Decoupling these components enables recovery from harness failure (reboot a new harness, reload the session event log, resume) and treats sandboxes as replaceable resources provisioned on demand.
 
 The same engineering documentation frames a structural security boundary: untrusted code generated by the model should not run in the same environment as credentials. Two concrete patterns are described: bundling auth with resources during sandbox initialization (e.g., repo token wired into git remote) or storing OAuth tokens in a secure vault and invoking tools through an MCP proxy that fetches credentials from the vault while the harness and sandbox never see them.
 
@@ -117,27 +117,27 @@ Anthropic's research on [effective harnesses for long-running agents](https://ww
 
 Databricks positions [Agent Bricks](https://www.databricks.com/product/artificial-intelligence/agent-bricks) as a unified platform to build and govern AI agents, explicitly describing persistent memory with Lakebase and the ability to schedule agents on recurring workflows, plus automatic capture of interactions, tool calls, and model invocations. These are direct signals that the platform is designed for always-on and scheduled operation rather than only interactive chat.
 
-Databricks documentation on [AI agent memory](https://docs.databricks.com/aws/en/generative-ai/agent-framework/stateful-agents) defines short-term memory as capturing context within a session using thread IDs and checkpointing, and long-term memory as extracting and storing key information across multiple conversations. LangGraph checkpointing backed by Lakebase provides durable state management, and a template using OpenAI Agents SDK sessions persisted to Lakebase indicates a multi-framework strategy for statefulness. The memory scaling proposal frames the agent's state as living in a persistent store — skills, knowledge, episodic and semantic memory — and positions the LLM as a swappable reasoning engine that reads the same memory store. From this pattern, we infer that long-term differentiation could accrue at the deployment level rather than the model level: the persistent context an agent accumulates over weeks of operation may become its primary asset, independent of which model powers its reasoning. This suggests a shift in differentiation from model capability to accumulated context, potentially making long-running deployments strategically valuable over time.
+Databricks documentation on [AI agent memory](https://docs.databricks.com/aws/en/generative-ai/agent-framework/stateful-agents) defines short-term memory as capturing context within a session using thread IDs and checkpointing, and long-term memory as extracting and storing key information across multiple conversations. LangGraph checkpointing backed by Lakebase provides durable state management, and a template using OpenAI Agents SDK sessions persisted to Lakebase indicates a multi-framework strategy for statefulness. The memory scaling proposal frames the agent's state as living in a persistent store (skills, knowledge, episodic and semantic memory), and positions the LLM as a swappable reasoning engine that reads the same memory store. From this pattern, we infer that long-term differentiation could accrue at the deployment level rather than the model level: the persistent context an agent accumulates over weeks of operation may become its primary asset, independent of which model powers its reasoning. This suggests a shift in differentiation from model capability to accumulated context, potentially making long-running deployments strategically valuable over time.
 
 Databricks also provides an explicit long-running mechanism for complex tasks: Supervisor Agent long-running task mode describes automatic task continuation by breaking long tasks into multiple request/response cycles, emitting `task_continue_request` events, and resuming via follow-up requests until completion. This is a concrete mechanism for agents that keep making progress across multiple cycles without timing out, and can be mapped directly to after-hours progress in enterprise workflows.
 
-Databricks documentation on [agent tools](https://docs.databricks.com/aws/en/generative-ai/agent-framework/agent-tool) describes tool integration via managed MCP servers, external MCP servers, and custom tools, with managed OAuth and a connections proxy as mechanisms to connect to third-party APIs. The build, evaluate, and deploy documentation describes operational concerns that matter for persistent systems: tracking configuration and versioning, measuring reliability through evaluation suites, and deployment with autoscaling, logging, version control, and access control. A Review App for subject matter experts to provide structured feedback closes the loop between agent output and human evaluation — a pattern that becomes essential when agents produce work products outside business hours that require review before they take effect.
+Databricks documentation on [agent tools](https://docs.databricks.com/aws/en/generative-ai/agent-framework/agent-tool) treats tool access as a centrally governed surface, with managed MCP servers handling third-party integrations under shared credentials. A Review App lets subject matter experts evaluate agent output after the fact, a pattern that becomes essential when agents produce work products outside business hours that require review before they take effect.
 
-The governance dimension is anchored to Unity Catalog. Databricks emphasizes unified governance over agents, tools, and MCP servers with end-to-end permissions, positioning MCP as a single governed protocol for connecting tools and data with centrally managed credentials and audit trails. Unity Catalog provides the enterprise primitives — access control, lineage tracking, and credential management — that make agent tool access auditable and revocable at an organizational level rather than at an individual agent level.
+The governance dimension is anchored to Unity Catalog, which extends existing enterprise access control and audit primitives to agent and tool actions at the organizational level rather than per-agent.
 
-The Databricks partnership with Anthropic is documented via a press release describing native availability of Claude models and positioning the partnership as enabling customers to build and deploy AI agents that reason over their own data with production-level requirements for accuracy, security, and access control. This explicitly supports a Databricks-plus-Anthropic long-running agents narrative: Claude models provide the reasoning layer, Databricks provides the governance, persistence, and deployment infrastructure, and Unity Catalog provides the enterprise control plane that binds them together.
+The Databricks-Anthropic partnership reinforces this division: Claude models provide the reasoning layer, while Databricks provides the governance, persistence, and deployment infrastructure that turn long-running agents into operational systems.
 
 *Enterprise implication: Persistent agents become operational systems when integrated with scheduling, stateful storage, and enterprise governance frameworks. Databricks demonstrates this most explicitly by treating agent deployment as a governed data platform concern rather than an application-layer concern.*
 
 ## The Identity Anchor: Agents as Delegated Actors
 
-Long-running agents introduce a failure mode that does not exist in interactive systems: execution that outlives the intent that initiated it. In a request-response model, intent and execution are tightly coupled in time. In persistent systems, this coupling breaks — work continues after the initiating context has changed, expired, or become invalid. The constraint required is not improved reasoning but bounded execution, and identity-bound delegation is the mechanism that provides it. This is what makes always-on agents deployable in real organizations, not merely technically possible.
+Long-running agents introduce a failure mode that does not exist in interactive systems: execution that outlives the intent that initiated it. In a request-response model, intent and execution are tightly coupled in time. In persistent systems, this coupling breaks: work continues after the initiating context has changed, expired, or become invalid. The constraint required is not improved reasoning but bounded execution, and identity-bound delegation is the mechanism that provides it. This is what makes always-on agents deployable in real organizations, not merely technically possible.
 
 ### Delegated identity model
 
 Persistent agents are best modeled, we argue, as delegated actors rather than independent identities. Three roles separate concerns cleanly:
 
-The **subject** is the human principal whose intent is being carried forward. The **actor** is the agent runtime — a workload identity — performing tool calls on behalf of the subject. The **delegation chain** is the cryptographic and policy-bound record that the actor is permitted to act for the subject, scoped to a time window, audience, and action set.
+The **subject** is the human principal whose intent is being carried forward. The **actor** is the agent runtime (a workload identity) performing tool calls on behalf of the subject. The **delegation chain** is the cryptographic and policy-bound record that the actor is permitted to act for the subject, scoped to a time window, audience, and action set.
 
 OAuth 2.0 Token Exchange ([RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693)) defines a Security Token Service style protocol for exchanging tokens, explicitly supporting delegation and impersonation semantics. Identity vendors are operationalizing this pattern: Ping Identity's materials frame "delegation instead of impersonation," describing tokens that carry both the human subject identity and the agent identity via `act`/`may_act` claims, preserving an auditable chain of custody for downstream authorization decisions. Microsoft Entra describes agent identities (currently in preview) as specialized identity constructs for AI agents, arguing that identity models designed for humans and applications are insufficient as organizations deploy autonomous systems at enterprise scale.
 
@@ -149,11 +149,11 @@ From the vendor-documented patterns analyzed in this paper, identity-bound deleg
 
 **Revocation.** Execution can be halted when intent changes. Long-running agents do not require explicit shutdown; their authority can expire or be withdrawn. The OpenID CAEP specification defines continuous access evaluation signals intended to attenuate access for human or robotic users, devices, sessions, and applications. Microsoft Entra describes CAE as an industry standard based on CAEP with near real-time enforcement goals.
 
-**Scoped authority.** Work can be assigned to agents without granting permanent or shared credentials. Authority is scoped to the specific task and context, preventing what we term the "authorization outlives intent" failure mode — a risk pattern consistent with the identity concerns Okta raises in its agent token exchange guidance for always-on agents.
+**Scoped authority.** Work can be assigned to agents without granting permanent or shared credentials. Authority is scoped to the specific task and context, preventing what we term the "authorization outlives intent" failure mode, a risk pattern consistent with the identity concerns Okta raises in its agent token exchange guidance for always-on agents.
 
 **Isolation.** Agents operating in shared environments do not inherit shared authority. Each task remains bound to its originating identity and scope, addressing the multi-user authority collapse risk documented in OpenClaw's security guidance.
 
-These properties are not enhancements. They are prerequisites for allowing agents to operate continuously within enterprise systems. Identity-bound governance constrains execution, not cognition — it does not improve model reasoning or guarantee correctness of outputs. Its role is to ensure that when agents act, they do so within enforceable and observable boundaries.
+These properties are not enhancements. They are prerequisites for allowing agents to operate continuously within enterprise systems. Identity-bound governance constrains execution, not cognition; it does not improve model reasoning or guarantee correctness of outputs. Its role is to ensure that when agents act, they do so within enforceable and observable boundaries.
 
 ## Reference Architecture
 
@@ -164,76 +164,80 @@ The following reference architecture organizes persistent agent infrastructure i
 ### Architecture diagram
 
 ```mermaid
+%%{init: {'flowchart': {'nodeSpacing': 35, 'rankSpacing': 55, 'padding': 10}}}%%
 flowchart TB
-  subgraph IAM["Identity & session plane"]
-    IdP["IdP + Conditional Access<br/>SSO, MFA, device posture"]
-    Sess["Session policy<br/>lifetime + reauth cadence"]
-    CAE["Continuous evaluation<br/>CAE/CAEP signals"]
+  subgraph IAM["Identity and session plane"]
+    direction LR
+    IdP["IdP plus<br/>Conditional Access"]
+    Sess["Session policy"]
+    CAE["Continuous<br/>evaluation"]
   end
 
-  subgraph Delegation["Delegation & token plane"]
-    STS["Token exchange / OBO<br/>RFC 8693"]
-    Vault["Token vault<br/>rotation + revocation"]
+  subgraph Delegation["Delegation and token plane"]
+    direction LR
+    STS["Token exchange<br/>OBO / RFC 8693"]
+    Vault["Token vault"]
   end
 
   subgraph Agent["Persistent agent plane"]
-    Runtime["Agent runtime<br/>planner + workers"]
-    Memory["Persistent context store<br/>session log + memory + checkpoints"]
-    Gateway["Tool gateway<br/>single egress"]
-    Policy["Policy engine<br/>allow / approve / block"]
-    Audit["Audit + traces"]
+    direction TB
+    Runtime["Agent runtime"]
+    Memory["Persistent<br/>context store"]
+    Gateway["Tool gateway"]
+    Policy["Policy engine"]
   end
 
   subgraph Tools["Enterprise tool plane"]
-    APIs["Internal APIs / systems"]
-    Channels["Enterprise channels<br/>chat / tickets / email"]
+    direction LR
+    Channels["Enterprise<br/>channels"]
+    APIs["Internal APIs"]
   end
+
+  Audit["Audit and traces"]
 
   IdP --> Sess
   Sess --> STS
-  CAE --> IdP
-  CAE --> Vault
-
+  CAE -.-> IdP
+  CAE -.-> Vault
   STS --> Vault
   Vault --> Runtime
 
+  Channels --> Runtime
   Runtime <--> Memory
   Runtime --> Gateway
-  Channels --> Runtime
   Gateway --> Policy
   Policy -->|allow| APIs
-  Policy -->|approve| IdP
   Policy -->|block| Audit
+  Policy -. approve .-> IdP
   APIs --> Runtime
 
   Runtime --> Audit
   Gateway --> Audit
-  Policy --> Audit
 ```
 
 ### Component mappings to citable building blocks
 
-**Identity & session plane.** User authentication flows through existing IdP infrastructure. Okta's global session policies explicitly support prompting frequency — setting the time before prompting for another challenge — which provides a native control plane for bounded agent session renewal. Google's session controls configure how often users must re-authenticate and whether full login, password-only, or hardware security key is required, directly supporting agent check-in renewal cadences. Microsoft Entra's Conditional Access policies enforce device compliance gates (via Intune) and granular step-up authentication using authentication context, enabling device-posture-gated agent session initiation and renewal. These are not new infrastructure requirements. They are existing enterprise controls extended to cover a new class of workload — the persistent agent.
+**Identity & session plane.** User authentication flows through existing IdP infrastructure. Okta's global session policies explicitly support prompting frequency (setting the time before prompting for another challenge), which provides a native control plane for bounded agent session renewal. Google's session controls configure how often users must re-authenticate and whether full login, password-only, or hardware security key is required, directly supporting agent check-in renewal cadences. Microsoft Entra's Conditional Access policies enforce device compliance gates (via Intune) and granular step-up authentication using authentication context, enabling device-posture-gated agent session initiation and renewal. These are not new infrastructure requirements. They are existing enterprise controls extended to cover a new class of workload: the persistent agent.
 
-**Delegation & token plane.** A token exchange or on-behalf-of flow mints a downscoped delegated token for the agent runtime. Okta documents OBO token exchange as retaining user context in requests to downstream services. Okta's agent-specific token exchange guidance (Early Access) explicitly positions token exchange as the mechanism to let AI agents access protected resources on behalf of authenticated users. Token Exchange ([RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693)) provides the protocol backbone as a standards-based mechanism for exchanging tokens, explicitly supporting delegation and impersonation use cases. Ping Identity's delegation framing embeds both identities in the token — the human subject (`sub`) and the agent actor (`act`/`may_act`) — preserving an auditable chain of custody for downstream authorization decisions.
+**Delegation & token plane.** A token exchange or on-behalf-of flow mints a downscoped delegated token for the agent runtime. Okta documents OBO token exchange as retaining user context in requests to downstream services. Okta's agent-specific token exchange guidance (Early Access) explicitly positions token exchange as the mechanism to let AI agents access protected resources on behalf of authenticated users. Token Exchange ([RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693)) provides the protocol backbone as a standards-based mechanism for exchanging tokens, explicitly supporting delegation and impersonation use cases. Ping Identity's delegation framing embeds both identities in the token, the human subject (`sub`) and the agent actor (`act`/`may_act`), preserving an auditable chain of custody for downstream authorization decisions.
 
 Refresh token rotation (documented by both Okta and Auth0) minimizes replay risk and reduces the blast radius of stolen tokens in long-lived delegated systems. Auth0's Continuous Session Protection provides customizable session and refresh token management controls for enterprise security requirements, including revocation and tailored lifetimes.
 
 The token vault stores credentials outside agent memory and execution environments, implementing the structural credential isolation described in Anthropic's managed agents documentation. This is not cosmetic: untrusted generated code can access credentials in the same container environment, and the structural fix is to keep tokens unreachable from the sandbox. Two concrete patterns are documented: bundling auth with resources during sandbox initialization (e.g., repo token wired into git remote) or storing OAuth tokens in a secure vault and invoking tools through an MCP proxy that fetches credentials from the vault while the harness and sandbox never see them.
 
-**Persistent agent plane.** The durable session log maps to Anthropic's session as an append-only log outside the harness and sandbox, retrievable as an event stream. This enables recovery from harness failure: reboot a new harness, reload the session event log, resume. Task records and provenance map to OpenClaw's background task ledger for detached work — cron runs, subagent spawns, CLI runs — where tasks function as traceable activity logs rather than execution triggers (described in OpenClaw's documentation as "records, not schedulers"), with explicit lifecycle tracking (`queued → running → terminal`) and notification delivery semantics. Memory and checkpoints map to Databricks agent memory with Lakebase as a durable store (short-term via thread IDs and checkpointing, long-term across sessions) and to OpenClaw's file-backed `MEMORY.md` persistence with optional scheduled consolidation via dreaming jobs. The policy/approval gate maps to NemoClaw's operator approval for unlisted network destinations and to Anthropic's per-action permissions model (always allow / needs approval / block).
+**Persistent agent plane.** The durable session log maps to Anthropic's session as an append-only log outside the harness and sandbox, retrievable as an event stream. This enables recovery from harness failure: reboot a new harness, reload the session event log, resume. Task records and provenance map to OpenClaw's background task ledger for detached work (cron runs, subagent spawns, CLI runs), where tasks function as traceable activity logs rather than execution triggers (described in OpenClaw's documentation as "records, not schedulers"), with explicit lifecycle tracking (`queued → running → terminal`) and notification delivery semantics. Memory and checkpoints map to Databricks agent memory with Lakebase as a durable store (short-term via thread IDs and checkpointing, long-term across sessions) and to OpenClaw's file-backed `MEMORY.md` persistence with optional scheduled consolidation via dreaming jobs. The policy/approval gate maps to NemoClaw's operator approval for unlisted network destinations and to Anthropic's per-action permissions model (always allow / needs approval / block).
 
 **Enterprise tool plane.** All tool access is mediated through a gateway and policy enforcement point. Continuation maps to Databricks' task continuation mechanism for long tasks exceeding timeouts (`task_continue_request` / `task_continue_response` loops) and to Anthropic's asynchronous long-running work positioning. AWS AgentCore Gateway positions itself as a secure connectivity layer converting APIs and Lambda functions into MCP-compatible tools reachable through gateway endpoints. Databricks' tool integration via managed MCP servers with managed OAuth and a connections proxy provides a governed variant where credential management and access control are centralized in Unity Catalog rather than managed per-agent.
 
 ### Operational flows
 
-**Session initiation and delegation.** A user authenticates via SSO under existing policies — MFA, conditional access, device posture. Okta global session policies explicitly support prompting frequency, and Google session controls explicitly support reauthentication methods and intervals. A token exchange or OBO flow mints a downscoped delegated token for the agent runtime. Okta documents OBO token exchange as preserving user context in downstream requests. The agent begins work with bounded authority that is traceable to the initiating user, and the delegated token encodes both who requested (subject) and what acts (actor) for downstream authorization decisions.
+**Session initiation and delegation.** A user authenticates via SSO under existing policies: MFA, conditional access, device posture. Okta global session policies explicitly support prompting frequency, and Google session controls explicitly support reauthentication methods and intervals. A token exchange or OBO flow mints a downscoped delegated token for the agent runtime. Okta documents OBO token exchange as preserving user context in downstream requests. The agent begins work with bounded authority that is traceable to the initiating user, and the delegated token encodes both who requested (subject) and what acts (actor) for downstream authorization decisions.
 
-**Renewable sessions and continuous evaluation.** The delegated token is short-lived; renewals occur through controlled exchanges. CAEP defines continuous updates enabling receivers to attenuate access to sessions, devices, and robotic users. Microsoft Entra describes CAE as an industry standard based on CAEP with near-real-time enforcement goals, though with possible latency due to event propagation. Practically, this enables revocation on critical events — risk changes, device posture changes, policy updates — rather than waiting for access token expiry. A deployment should measure end-to-end revocation latency to ensure the governance expectation is met.
+**Renewable sessions and continuous evaluation.** The delegated token is short-lived; renewals occur through controlled exchanges. CAEP defines continuous updates enabling receivers to attenuate access to sessions, devices, and robotic users. Microsoft Entra describes CAE as an industry standard based on CAEP with near-real-time enforcement goals, though with possible latency due to event propagation. Practically, this enables revocation on critical events (risk changes, device posture changes, policy updates) rather than waiting for access token expiry. A deployment should measure end-to-end revocation latency to ensure the governance expectation is met.
 
 **Token vaulting and credential lifecycle.** Refresh tokens and delegated credentials are stored in a dedicated token vault rather than in agent memory or local files. Refresh token rotation guidance from Okta and Auth0 highlights rotation behavior and revocation implications as first-class controls. OAuth Security Best Current Practice ([RFC 9700](https://datatracker.ietf.org/doc/rfc9700/)) updates threat modeling for broad OAuth usage and provides a suitable baseline for vault design. The vault is a structural control: it ensures that even if the agent's execution environment is compromised, credentials are not directly accessible.
 
-**Tool execution via gateway and policy engine.** All tool calls traverse a single gateway that enforces allow/approve/block decisions, records traces, and integrates step-up authentication or human review where needed. The gateway is the enforcement boundary: the agent cannot bypass it. OpenAI's guardrails documentation defines human review as a runtime pause that gates sensitive tool actions, supporting enforceable approvals without breaking workflow continuity. AWS AgentCore Gateway and Ping Identity's agent gateway framing each implement this as a first-class architecture layer — a security proxy validating delegation tokens and enforcing runtime authorization in front of protected resources. NemoClaw's deny-by-default egress implements the same principle at the environment boundary, intercepting unlisted destinations and surfacing them for operator approval in real time.
+**Tool execution via gateway and policy engine.** All tool calls traverse a single gateway that enforces allow/approve/block decisions, records traces, and integrates step-up authentication or human review where needed. The gateway is the enforcement boundary: the agent cannot bypass it. OpenAI's guardrails documentation defines human review as a runtime pause that gates sensitive tool actions, supporting enforceable approvals without breaking workflow continuity. AWS AgentCore Gateway and Ping Identity's agent gateway framing each implement this as a first-class architecture layer: a security proxy validating delegation tokens and enforcing runtime authorization in front of protected resources. NemoClaw's deny-by-default egress implements the same principle at the environment boundary, intercepting unlisted destinations and surfacing them for operator approval in real time.
 
 **After-hours progress.** The user initiates a task, the system produces a task record with provenance (who, why, when), and the harness continues running the work loop until the next check-in point or approval gate, emitting updates back to the initiating user. The delegated token's lifetime and renewal requirements ensure that work does not continue indefinitely without governance checks. Anthropic's long-running harness research describes this explicitly: an initializer session scaffolds environment artifacts, then recurring coding sessions make incremental progress while leaving structured artifacts (progress logs, commits) for the next session. The system is designed for multi-session work spanning hours or days, with each session's output serving as input for the next.
 
@@ -243,7 +247,7 @@ The token vault stores credentials outside agent memory and execution environmen
 
 The productivity implications of long-running agents do not arise from faster responses. They arise from temporal decoupling.
 
-Interactive systems are bounded by human working time. Persistent systems are bounded by system constraints — compute, API rate limits, and policy gates — rather than by whether a human is actively watching.
+Interactive systems are bounded by human working time. Persistent systems are bounded by system constraints (compute, API rate limits, and policy gates) rather than by whether a human is actively watching.
 
 ### The core mechanism: cycle-time reduction
 
@@ -264,9 +268,9 @@ The productivity model implied by persistent agents is fundamentally different f
 | Human + interactive copilot | Bounded by human working hours | Individual task speed |
 | Human + always-on agents | Bounded by system constraints | Temporal coverage and throughput |
 
-The argument is that productivity equals time multiplied by coverage, not speed alone. A developer who dispatches three coding agents at end-of-day — one running tests against a refactored module, one collecting benchmark data, one triaging a backlog of lint warnings — returns the next morning to completed work products rather than a cold start. The developer's own speed has not changed. The workflow's cycle time has compressed because idle hours became execution hours.
+The argument is that productivity equals time multiplied by coverage, not speed alone. A developer who dispatches three coding agents at end-of-day (one running tests against a refactored module, one collecting benchmark data, one triaging a backlog of lint warnings) returns the next morning to completed work products rather than a cold start. The developer's own speed has not changed. The workflow's cycle time has compressed because idle hours became execution hours.
 
-A common pattern where this effect is most visible is CI/CD pipelines, where build, test, and validation steps are inherently asynchronous. Persistent agents can orchestrate these steps continuously — triggering the next stage as soon as the previous one completes, handling transient failures with retries, and collecting results for human review — reducing idle time between stages without requiring human re-initiation at each step.
+A common pattern where this effect is most visible is CI/CD pipelines, where build, test, and validation steps are inherently asynchronous. Persistent agents can orchestrate these steps continuously (triggering the next stage as soon as the previous one completes, handling transient failures with retries, and collecting results for human review), reducing idle time between stages without requiring human re-initiation at each step.
 
 ### Empirical constraints
 
@@ -274,33 +278,33 @@ This effect is not universal. Tasks requiring continuous human judgment or high-
 
 A field experiment analysis of GitHub Copilot ([Cui et al., MIT GenAI](https://mit-genai.pubpub.org/pub/v5iixksv)) reports suggestive increases in pull requests completed per week in some organizational settings, though the authors emphasize limitations such as compliance and precision. Conversely, a randomized controlled trial of experienced open-source developers ([Becker et al., METR, arXiv:2507.09089, July 2025](https://metr.org/blog/2025-07-10-early-2025-ai-experienced-os-dev-study/)) reported that allowing AI tools increased completion time by 19%, contradicting developer expectations.
 
-A paper arguing for beyond-work-hours productivity is therefore strongest when it frames the claim as enabled by long-running architectures documented by vendors and requiring enterprise evaluation metrics — cycle time, PR lead time, defect rate, human review load — rather than relying on sentiment or self-reported speed. The productivity hypothesis is testable. It has not yet been tested at enterprise scale.
+A paper arguing for beyond-work-hours productivity is therefore strongest when it frames the claim as enabled by long-running architectures documented by vendors and requiring enterprise evaluation metrics (cycle time, PR lead time, defect rate, human review load) rather than relying on sentiment or self-reported speed. The productivity hypothesis is testable. It has not yet been tested at enterprise scale.
 
 ## Comparison Table
 
 The following table compares representative systems across the architectural dimensions analyzed in this paper. "Unspecified" indicates the relevant primary documentation does not clearly describe the attribute.
 
-| Solution | Persistence model | Identity anchoring | Policy / gateway | Deployment | Maturity |
-|---|---|---|---|---|---|
-| **OpenClaw** | File-backed memory (`MEMORY.md`, daily notes) loaded automatically; gateway-centric architecture | Unspecified (security guidance: routing keys are not authorization) | Gateway is control plane; exec approvals as intent guardrails | Self-hosted (MIT) | Active OSS |
-| **NemoClaw** | Persistent sandbox workspace files; explicit sandbox policy model | Unspecified | Deny-by-default egress; operator approval on unlisted destinations; OpenShell policy layers | Self-hosted (Apache-2.0) | Alpha / early preview |
-| **Anthropic Managed Agents** | Append-only session log; harness/sandbox separation; session survives harness failure | Credential vaulting via MCP proxy; structural sandbox isolation | Per-action permissions (allow/approve/block); sandboxed execution | Managed service | Production documentation |
-| **Databricks Agent Bricks** | Lakebase-backed memory; thread checkpointing; long-term cross-session memory | IAM-centric; Unity Catalog governance | MCP servers; managed OAuth; connections proxy; task continuation | Managed service | Production cloud service |
-| **LangGraph** | Built-in checkpoint persistence; state saved at each step, organized into threads | Unspecified | HITL via persistence; gateway primitives unspecified | Self-hosted (MIT) | Mature OSS |
-| **OpenAI Agents SDK** | Application-defined persistence; SDK provides orchestration, tracing, approvals | Unspecified | Guardrails + human review; tracing and handoffs as first-class primitives | Self-hosted (MIT) | Official vendor SDK |
-| **AWS Bedrock Agents** | Managed construct; tool actions formalized via action groups | IAM-centric | Action groups; AgentCore Gateway as tool connectivity layer | AWS managed service | Production |
+| Solution | Persistence model | Identity anchoring | Policy / gateway | Status |
+|---|---|---|---|---|
+| **OpenClaw** | File-backed memory (`MEMORY.md`, daily notes) loaded automatically; gateway-centric architecture | Unspecified; security guidance notes routing keys are not authorization | Gateway is control plane; exec approvals as intent guardrails | OSS (MIT), active |
+| **NemoClaw** | Persistent sandbox workspace files; explicit sandbox policy model | Unspecified | Deny-by-default egress; operator approval on unlisted destinations; OpenShell policy layers | OSS (Apache-2.0), alpha |
+| **Anthropic Managed Agents** | Append-only session log; harness/sandbox separation; session survives harness failure | Credential vaulting via MCP proxy; structural sandbox isolation | Per-action permissions (allow/approve/block); sandboxed execution | Managed, production |
+| **Databricks Agent Bricks** | Lakebase-backed memory; thread checkpointing; long-term cross-session memory | IAM-centric; Unity Catalog governance | MCP servers; managed OAuth; connections proxy; task continuation | Managed, production |
+| **LangGraph** | Built-in checkpoint persistence; state saved per step, organized into threads | Unspecified | HITL via persistence; gateway primitives unspecified | OSS (MIT), mature |
+| **OpenAI Agents SDK** | Application-defined persistence; SDK provides orchestration, tracing, approvals | Unspecified | Guardrails and human review; tracing and handoffs as first-class primitives | OSS (MIT), vendor SDK |
+| **AWS Bedrock Agents** | Managed construct; tool actions formalized via action groups | IAM-centric | Action groups; AgentCore Gateway as tool connectivity layer | Managed (AWS), production |
 
-Two patterns emerge from this comparison. First, based on the documentation surveyed, identity anchoring appears to be the least mature dimension across the landscape — most systems treat it as an external concern rather than a first-class architectural component, and several major frameworks leave it entirely unspecified. Second, policy and gateway primitives are increasingly built into agent platforms rather than bolted on, suggesting convergence toward tool-boundary governance as a baseline expectation.
+Two patterns emerge from this comparison. First, based on the documentation surveyed, identity anchoring appears to be the least mature dimension across the landscape; most systems treat it as an external concern rather than a first-class architectural component, and several major frameworks leave it entirely unspecified. Second, policy and gateway primitives are increasingly built into agent platforms rather than bolted on, suggesting convergence toward tool-boundary governance as a baseline expectation.
 
 ## Conclusion
 
 Persistent agents are a structural evolution of enterprise automation. They extend work across time, retain durable context, and act through tools. The enterprise control problem is not whether agents are safe in the abstract, but whether agent autonomy is bounded by renewable sessions, attributable to human intent, and enforced at unbypassable control points.
 
-This paper has argued that always-on agents become deployable — not merely technically possible — when three conditions are met. First, persistence is externalized: sessions, memory, and task state live outside the model context window in durable, inspectable stores. The evidence from OpenClaw, Anthropic, and Databricks demonstrates convergence on this pattern. Second, execution is identity-bound: every action traces to a human subject through a delegation chain that can be audited, scoped, and revoked. Identity standards (RFC 8693, CAEP) and vendor implementations (Okta, Microsoft Entra, Ping Identity) provide the protocol infrastructure. Third, tool boundaries are governed: a gateway and policy engine mediate all side effects, enforcing allow/approve/block decisions independently of the agent's reasoning.
+This paper has argued that always-on agents become deployable, not merely technically possible, when three conditions are met. First, persistence is externalized: sessions, memory, and task state live outside the model context window in durable, inspectable stores. The evidence from OpenClaw, Anthropic, and Databricks demonstrates convergence on this pattern. Second, execution is identity-bound: every action traces to a human subject through a delegation chain that can be audited, scoped, and revoked. Identity standards (RFC 8693, CAEP) and vendor implementations (Okta, Microsoft Entra, Ping Identity) provide the protocol infrastructure. Third, tool boundaries are governed: a gateway and policy engine mediate all side effects, enforcing allow/approve/block decisions independently of the agent's reasoning.
 
-These three conditions map directly to the series formula. Specification quality defines what an agent should do. Loop autonomy defines how it executes. Persistent context management sustains execution across time. And identity-bound governance ensures that sustained execution remains aligned with human intent — not through prompt discipline, but through structural enforcement.
+These three conditions map directly to the framework established earlier in the series. Specification quality defines what an agent should do. Loop autonomy defines how it executes. Persistent context management sustains execution across time. And identity-bound governance ensures that sustained execution remains aligned with human intent, not through prompt discipline, but through structural enforcement.
 
-The productivity hypothesis — that always-on agents compress cycle time by converting idle hours into execution hours — is grounded in the architectural capabilities described in this paper, not in empirical proof of enterprise-scale gains. It is, however, not yet validated at enterprise scale. Organizations evaluating persistent agent deployments should instrument for cycle time, throughput, and review load rather than relying on self-reported productivity gains.
+The productivity hypothesis, that always-on agents compress cycle time by converting idle hours into execution hours, is grounded in the architectural capabilities described in this paper, not in empirical proof of enterprise-scale gains. It is, however, not yet validated at enterprise scale. Organizations evaluating persistent agent deployments should instrument for cycle time, throughput, and review load rather than relying on self-reported productivity gains.
 
 The transition from interactive copilots to persistent agents is not incremental. It is a shift from tools to infrastructure. Identity-bound governance is what makes that shift viable.
 

--- a/docs/papers/always-on-agents/index.md
+++ b/docs/papers/always-on-agents/index.md
@@ -363,6 +363,16 @@ The transition from interactive copilots to persistent agents is not incremental
 - [Agentic Development Tools and Execution Architectures](/papers/agentic-tools/)
 - [Spec-Driven Development Framework Patterns](/papers/sdd-frameworks/)
 
+## Citation
+
+If citing this research in academic or professional work:
+
+```
+Daniel, David (2026). Always-On Enterprise Agents: Persistent Architecture,
+Delegated Identity, and the Productivity Hypothesis.
+Retrieved from https://daviddaniel.tech/research/papers/always-on-agents/
+```
+
 ---
 
 *This paper is Part 3 of a series on scaling agentic development for enterprise teams. Part 1, [The Specification Layer](/articles/specification-layer/), covers why specifications are the missing enterprise scaling strategy. Part 2, [The Autonomous Agents Loop](/articles/autonomous-agents-loop/), covers why autonomous execution loops outperform interactive assistance. For the empirical evidence base on autonomous execution, see the companion paper [Autonomous AI Agents: Execution Loops vs Interactive Assistance](/papers/autonomous-agents/).*

--- a/docs/papers/always-on-agents/index.md
+++ b/docs/papers/always-on-agents/index.md
@@ -359,6 +359,7 @@ The transition from interactive copilots to persistent agents is not incremental
 
 - [The Specification Layer](/articles/specification-layer/)
 - [The Autonomous Agents Loop](/articles/autonomous-agents-loop/)
+- [The Security Debt of Always-On Agents](/articles/security-debt-always-on-agents/)
 - [Autonomous AI Agents: Execution Loops vs Interactive Assistance](/papers/autonomous-agents/)
 - [Agentic Development Tools and Execution Architectures](/papers/agentic-tools/)
 - [Spec-Driven Development Framework Patterns](/papers/sdd-frameworks/)

--- a/docs/papers/always-on-agents/index.md
+++ b/docs/papers/always-on-agents/index.md
@@ -360,6 +360,7 @@ The transition from interactive copilots to persistent agents is not incremental
 - [The Specification Layer](/articles/specification-layer/)
 - [The Autonomous Agents Loop](/articles/autonomous-agents-loop/)
 - [The Security Debt of Always-On Agents](/articles/security-debt-always-on-agents/)
+- [From Copilot to Principal: How Always-On Agents Reorganize Knowledge Work](/articles/copilot-to-principal/)
 - [Autonomous AI Agents: Execution Loops vs Interactive Assistance](/papers/autonomous-agents/)
 - [Agentic Development Tools and Execution Architectures](/papers/agentic-tools/)
 - [Spec-Driven Development Framework Patterns](/papers/sdd-frameworks/)

--- a/docs/papers/always-on-agents/index.md
+++ b/docs/papers/always-on-agents/index.md
@@ -7,7 +7,7 @@ date: 2026-04-13
 
 # Always-On Enterprise Agents: Persistent Architecture, Delegated Identity, and the Productivity Hypothesis
 
-*Part 3 of Scaling Agentic Development for Enterprise Teams*
+*From the Scaling Agentic Development for Enterprise Teams research series*
 
 **Published:** April 2026 | **Author:** David Daniel
 
@@ -27,7 +27,7 @@ The analysis draws on primary documentation from OpenClaw, NVIDIA NemoClaw, Anth
 
 ## Introduction
 
-The first two parts of this series proposed a framework for enterprise AI scaling, identifying three interdependent factors that together determine reliable output at scale: specification quality, loop autonomy, and context management. Part 1 argued that machine-readable specifications are the missing foundation for agentic scaling. Part 2 argued that longer autonomous execution with multi-agent context management outperforms interactive assistance. This paper extends both arguments into persistent territory: what happens when autonomous execution persists across sessions, hours, and organizational boundaries.
+Earlier work in this research series proposed a framework for enterprise AI scaling, identifying three interdependent factors that together determine reliable output at scale: specification quality, loop autonomy, and context management. The companion article [The Specification Layer](/articles/specification-layer/) argued that machine-readable specifications are the missing foundation for agentic scaling. The companion article [The Autonomous Agents Loop](/articles/autonomous-agents-loop/) argued that longer autonomous execution with multi-agent context management outperforms interactive assistance. This paper extends both arguments into persistent territory: what happens when autonomous execution persists across sessions, hours, and organizational boundaries.
 
 Persistent agents represent a shift in the shape of enterprise automation. Instead of request/response interaction constrained to a chat session, persistent agents retain durable context and produce durable work products across time: plans, tickets, diffs, runbooks, approvals, and tool-executed side effects. Anthropic's Claude Managed Agents is explicitly positioned as "best for long-running tasks and asynchronous work," and its engineering documentation formalizes long-running operation as a durable session log plus a harness that can resume after failure and a sandboxed execution layer that can be replaced without losing the session. Databricks is productizing stateful and long-running agent operation in a governed data platform: Agent Bricks explicitly supports scheduling agents on recurring workflows, capturing tool calls and invocations, and giving agents persistent memory via Lakebase. OpenClaw provides an inspectable open-source example of always-on operation with explicit session lifecycle policies and file-backed memory persistence.
 
@@ -302,7 +302,7 @@ Persistent agents are a structural evolution of enterprise automation. They exte
 
 This paper has argued that always-on agents become deployable, not merely technically possible, when three conditions are met. First, persistence is externalized: sessions, memory, and task state live outside the model context window in durable, inspectable stores. The evidence from OpenClaw, Anthropic, and Databricks demonstrates convergence on this pattern. Second, execution is identity-bound: every action traces to a human subject through a delegation chain that can be audited, scoped, and revoked. Identity standards (RFC 8693, CAEP) and vendor implementations (Okta, Microsoft Entra, Ping Identity) provide the protocol infrastructure. Third, tool boundaries are governed: a gateway and policy engine mediate all side effects, enforcing allow/approve/block decisions independently of the agent's reasoning.
 
-These three conditions map directly to the framework established earlier in the series. Specification quality defines what an agent should do. Loop autonomy defines how it executes. Persistent context management sustains execution across time. And identity-bound governance ensures that sustained execution remains aligned with human intent, not through prompt discipline, but through structural enforcement.
+These three conditions map directly to the framework established in earlier work in this series. Specification quality defines what an agent should do. Loop autonomy defines how it executes. Persistent context management sustains execution across time. And identity-bound governance ensures that sustained execution remains aligned with human intent, not through prompt discipline, but through structural enforcement.
 
 The productivity hypothesis, that always-on agents compress cycle time by converting idle hours into execution hours, is grounded in the architectural capabilities described in this paper, not in empirical proof of enterprise-scale gains. It is, however, not yet validated at enterprise scale. Organizations evaluating persistent agent deployments should instrument for cycle time, throughput, and review load rather than relying on self-reported productivity gains.
 
@@ -375,7 +375,7 @@ Retrieved from https://daviddaniel.tech/research/papers/always-on-agents/
 
 ---
 
-*This paper is Part 3 of a series on scaling agentic development for enterprise teams. Part 1, [The Specification Layer](/articles/specification-layer/), covers why specifications are the missing enterprise scaling strategy. Part 2, [The Autonomous Agents Loop](/articles/autonomous-agents-loop/), covers why autonomous execution loops outperform interactive assistance. For the empirical evidence base on autonomous execution, see the companion paper [Autonomous AI Agents: Execution Loops vs Interactive Assistance](/papers/autonomous-agents/).*
+*This paper is part of an ongoing research series on scaling agentic development for enterprise teams. Related work includes the companion paper [Autonomous AI Agents: Execution Loops vs Interactive Assistance](/papers/autonomous-agents/) for the empirical evidence base on autonomous execution, along with the practitioner articles [The Specification Layer](/articles/specification-layer/) on machine-readable specifications as enterprise scaling infrastructure and [The Autonomous Agents Loop](/articles/autonomous-agents-loop/) on why autonomous execution loops outperform interactive assistance.*
 
 *This paper is part of an ongoing research project tracking AI tooling, software engineering practices, and cross-functional workflows at [daviddaniel.tech/research](https://daviddaniel.tech/research).*
 

--- a/docs/papers/index.md
+++ b/docs/papers/index.md
@@ -11,6 +11,16 @@ In-depth technical analysis to help engineers evaluate frameworks, tools, and pr
 
 ---
 
+### [Always-On Enterprise Agents: Persistent Architecture, Delegated Identity, and the Productivity Hypothesis](/papers/always-on-agents/)
+
+A research taxonomy of persistent agent patterns for enterprise deployments, grounded in primary vendor documentation. Covers session-anchored architecture, identity-bound governance, and the cycle-time productivity hypothesis.
+
+**Topics:** Persistent agents, identity-bound delegation, tool-boundary governance, reference architecture, cycle-time productivity
+
+[Read →](/papers/always-on-agents/)
+
+---
+
 ### [Autonomous AI Agents: Execution Loops vs Interactive Assistance](/papers/autonomous-agents/)
 
 Evidence synthesis comparing autonomous AI agent execution loops against interactive human-in-the-loop assistance, covering SWE-bench benchmarks, the METR RCT, industry telemetry, and adjacent domain evidence.


### PR DESCRIPTION
## Summary

This PR now bundles the Always-On Enterprise Agents research paper with its two companion practitioner articles in the "Scaling Agentic Development" series.

**Research paper** (`docs/papers/always-on-agents/`)
- Persistent enterprise agent architecture, identity-bound delegation, and the cycle-time productivity hypothesis.
- Reference architecture rendered as a Mermaid diagram (four planes: identity/session, delegation/token, persistent agent, enterprise tool) with audit/observability pulled out for clarity.
- Comparison table covers OpenClaw, NemoClaw, Anthropic Managed Agents, Databricks Agent Bricks, LangGraph, OpenAI Agents SDK, and AWS Bedrock Agents across persistence, identity anchoring, policy/gateway, and status.
- Frontmatter, footer, citation conventions, and disclaimer aligned with existing papers; Abstract heading matches the autonomous-agents paper convention.

**Part 3 article** – *The Security Debt of Always-On Agents* (`docs/articles/security-debt-always-on-agents/`)
- Practitioner companion to the paper. Argues that the enterprise security stack was built for human-shaped work and breaks down once agents interact with data and tools directly.
- Covers the data-first defensive architecture, the harness as the security-critical layer, and the five characteristics of a usable defensive posture for persistent agents.

**Part 4 article** – *From Copilot to Principal* (`docs/articles/copilot-to-principal/`)
- Argues that persistent always-on agents do not shrink the human role, they invert it, and that most organizations are not structurally ready for the principal role this creates.
- Introduces the "overnight test" diagnostic, frames judgment bandwidth as the new bottleneck, and explains why the harness matters more than the license.

**Cross-cutting alignment**
- Reframed Parts 1 and 2 subtitles away from strict "of 2" series framing and added Part 3 / Part 4 to their footers and Related Content lists.
- Articles index (`docs/articles/index.md`) updated to list the two new articles and the Always-On Enterprise Agents paper under Related Research.
- Sidebar in `docs/.vitepress/config.js` updated to include a shared "Scaling Agentic Development" sidebar group for all four articles.
- Always-On Enterprise Agents paper "Related Research on This Site" section now lists the two new companion articles.
- Em dashes removed from both new articles to match the project punctuation convention applied to the paper earlier on this branch.
- AI-assistance attribution at the end of the new articles now matches the inline-source format used by Parts 1 and 2.

## Test plan

- [x] `npm run docs:build` completes cleanly with all four articles + paper rendered
- [x] Sitemap generation includes the new article pages
- [x] RSS feed regenerated (22 posts)
- [x] Canonical URLs present and correct for the new article pages
- [x] Visually verify the architecture Mermaid diagram renders without clipping
- [x] Visually verify the comparison table fits within the viewport without horizontal scroll
- [x] Spot-check internal links and sidebar navigation on the deployed preview

https://claude.ai/code/session_016Sd9RpJit72mEwBYhsFZSH