### PR TITLE
fix(seo): add image + Organization publisher logo to article schema

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -7,6 +7,9 @@ const siteBase = '/research'
 const siteUrl = `${siteHostname}${siteBase}`
 const siteName = 'Research'
 const siteDescription = 'In-depth technical analysis on software development frameworks, AI-powered development, and engineering practices'
+// Brand logo is hosted by the root site at daviddaniel.tech/logo.png (same origin
+// as /research), so structured data references it by absolute URL — no copy needed here.
+const siteLogo = `${siteHostname}/logo.png`
 
 const rssOptions = {
   title: 'Research Papers - Technical Analysis on Software Development',
@@ -119,14 +122,21 @@ export default withMermaid(
           '@type': 'TechArticle',
           headline: title,
           description: description,
+          image: siteLogo,
           author: {
             '@type': 'Person',
             name: 'David Daniel',
             url: 'https://daviddaniel.tech'
           },
           publisher: {
-            '@type': 'Person',
-            name: 'David Daniel'
+            '@type': 'Organization',
+            name: 'David Daniel Research',
+            logo: {
+              '@type': 'ImageObject',
+              url: siteLogo,
+              width: 400,
+              height: 400
+            }
           },
           url: canonicalUrl,
           datePublished: pageData.frontmatter.date
@@ -156,6 +166,7 @@ export default withMermaid(
             '@type': 'WebPage',
             name: title,
             description: description,
+            image: siteLogo,
             url: canonicalUrl,
             author: {
               '@type': 'Person',


### PR DESCRIPTION
## What

Clears the non-critical Rich Results warnings on paper/article pages (flagged in the weekly SEO report) by completing the `TechArticle` / `WebPage` structured data in `docs/.vitepress/config.js`:

- Adds the recommended **`image`** field to `TechArticle` and `WebPage`.
- Switches the article **`publisher`** from `Person` to `Organization` with a **`logo`** `ImageObject` (Google expects an Organization publisher with a logo for Article rich-result eligibility).

## No duplicated asset

The logo is the existing brand mark already hosted by the root site at `https://daviddaniel.tech/logo.png` (verified live: `200`, `image/png`). Since `/research` is served from the **same origin**, the structured data references it by absolute URL. Nothing is copied into this repo; a single `siteLogo` constant holds the URL.

## Verification (built `dist/`)

| Page | Result |
|------|--------|
| `papers/sdd-frameworks/` (TechArticle) | `image` set; publisher = Organization "David Daniel Research" + logo |
| `articles/autonomous-agents-loop/` (TechArticle) | `image` set; publisher Organization + logo |
| `papers/` (WebPage hub) | `image` set |

`npm run docs:build` passes. Diff is config-only.

## Note

`logo.png` is 400×400, which clears the "missing image" warning. A larger 1200×630 social-share raster (also replacing the current SVG `og:image`, which platforms render poorly) is deliberately left as separate optional polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)